### PR TITLE
Removed arrow key navigation

### DIFF
--- a/_includes/views/post.js
+++ b/_includes/views/post.js
@@ -148,8 +148,6 @@ views.Post = Backbone.View.extend({
     this.prevContent = this.serialize();
     if (!window.shortcutsRegistered) {
       key('⌘+s, ctrl+s', _.bind(function() { this.updateFile(); return false; }, this));
-      key('ctrl+shift+right', _.bind(function() { this.right(); return false; }, this));
-      key('ctrl+shift+left', _.bind(function() { this.left(); return false; }, this));
       key('esc', _.bind(function() { this.toggleView('compose'); return false; }, this));
       window.shortcutsRegistered = true;
     }


### PR DESCRIPTION
Let's fix #135 by removing the bindings altogether.

I love using Prose but not being able to word-select is driving me crazy. Also there seems to be no easy alternative to ctrl+shift+left/right, so maybe it's just better to scrap this functionality?
