### PR TITLE
Fix jekyll compilation

### DIFF
--- a/_posts/help/2012-06-20-handbook.md
+++ b/_posts/help/2012-06-20-handbook.md
@@ -57,11 +57,9 @@ Essentially, this is as easy as including a link to the Prose edit page of the c
 
 For the Prose help pages we just added a `prose_link` property to the YAML frontmatter of our source files.
 
-```
----
-prose_link: http://prose.io/#prose/prose/edit/gh-pages/_posts/help/2012-06-20-internals.md
----
-```
+    ---
+    prose_link: http://prose.io/#prose/prose/edit/gh-pages/_posts/help/2012-06-20-internals.md
+    ---
 
 And in the help pages template used this markup:
 


### PR DESCRIPTION
Commit bb3d12a84989e4cc55b72c91db1338267ffb8fc7 broke Jekyll (Maruku) compilation, preventing the site from being rebuilt by to Github Pages. Output from Jekyll:

`````` ___________________________________________________________________________
| Maruku tells you:
+---------------------------------------------------------------------------
| String finished while reading (break on []) already read: ""
| ---------------------------------------------------------------------------
| ```EOF
| ---|------------------------------------------------------------------------
|    +--- Byte 3
| Shown bytes [0 to 3] of 3:
| >```
+---------------------------------------------------------------------------
``````

FYI my gems:

```
$ gem list

*** LOCAL GEMS ***

albino (1.3.3)
bundler (1.1.3)
classifier (1.3.3)
directory_watcher (1.4.1)
fast-stemmer (1.0.1)
jekyll (0.11.2)
kramdown (0.14.0)
liquid (2.4.1)
maruku (0.6.1)
posix-spawn (0.3.6)
rake (0.9.2.2)
rubygems-bundler (0.9.2)
rvm (1.11.3.3)
syntax (1.0.0)
```

Cheers,
Aslak
