### PR TITLE
Allow three consecutive hyphens in body, fixes #245.

### DIFF
--- a/_includes/model.js
+++ b/_includes/model.js
@@ -353,7 +353,7 @@ function loadPost(user, repo, branch, path, file, cb) {
       };
 
       var res = { raw_metadata: "", published: false };
-      res.content = content.replace(/(---\n)((.|\n)*?)\n---\n?/, function(match, dashes, frontmatter) {
+      res.content = content.replace(/^(---\n)((.|\n)*?)\n---\n?/, function(match, dashes, frontmatter) {
         res.raw_metadata = frontmatter;
         res.published = published(frontmatter);
         return "";


### PR DESCRIPTION
Parsing the YAML front matter from a post body broke if the post itself contained three consequtive hyphens (e.g., a heading).

Make the regex less greedy to look for the first set of closing hyphens (rather than the last set).
