### PR TITLE
Stop github oauth token from being sent over insecure connections

### DIFF
--- a/_includes/model.js
+++ b/_includes/model.js
@@ -54,7 +54,7 @@ function authenticate() {
   // Handle Code
   if (match) {
     $.getJSON('{{site.gatekeeper_url}}/authenticate/'+match[1], function(data) {
-      $.cookie('oauth-token', data.token);
+      $.cookie('oauth-token', data.token, { secure: true });
       window.authenticated = true;
       // Adjust URL
       var regex = new RegExp("\\?code="+match[1]);


### PR DESCRIPTION
At the moment Prose.io sends a cookie containing the github oauth token over unencrypted HTTP requests to http://prose.io. This leaves it vulnerable to [session hijacking](http://en.wikipedia.org/wiki/Session_hijacking). Since this cookie is only used to store the token for AJAX requests to the github servers (over https) there is no need for this to be sent on HTTP requests to http://prose.io

This commit simply adds `secure: true` to the cookie when it is created to ensure that it is not sent over http requests.
