### PR TITLE
Slightly more intuitive saving UI, tries to fix #240.

### DIFF
--- a/_includes/templates/post._
+++ b/_includes/templates/post._
@@ -12,7 +12,7 @@
     </div>
 
     <div class="fr menu-item save-state">
-      <input type="text" class="commit-message" value="Updated."/>
+      <input type="text" class="commit-message" value=""/>
       <div class="state fl">
         <% if (writeable) { %><a class='toggle-options button' href='#'>&nbsp;</a><% } %>
         

--- a/_includes/views/post.js
+++ b/_includes/views/post.js
@@ -57,7 +57,7 @@ views.Post = Backbone.View.extend({
 
   _toggleCommit: function() {
     if (!this.$('.document-menu').hasClass('commit')) {
-      this.$('.commit-message').val("Updated "+$('input.filepath').val());  
+      this.$('.commit-message').attr( 'placeholder', "Updated "+$('input.filepath').val());
     }
 
     this.hideMeta();
@@ -69,6 +69,7 @@ views.Post = Backbone.View.extend({
     this.showDiff();
     this.$('.surface').toggle();
     this.$('.diff-wrapper').toggle();
+    this.$('.commit-message').focus();  
 
     return false;
   },
@@ -306,7 +307,7 @@ views.Post = Backbone.View.extend({
         filepath = $('input.filepath').val(),
         filename = _.extractFilename(filepath)[1],
         filecontent = this.serialize(),
-        message = this.$('.commit-message').val(),
+        message = this.$('.commit-message').val() || this.$('.commit-message').attr('placeholder'),
         method = this.model.writeable ? this.saveFile : this.sendPatch;
 
     // Update content


### PR DESCRIPTION
On save, move focus to the commit message dialog, to encouage users to enter message.

In order to make this process more fluid, the default commit message was moved to `placeholder`, and is swapped in for `val()` on save if none is present.

May make sense to have someone with more design/UI sense take a pass, perhaps the commit box border changes on focus, the commit button changes color, etc. to stand out?
