### PR TITLE
Detect YAML frontmatter on any file, regardless of type

### DIFF
--- a/_includes/model.js
+++ b/_includes/model.js
@@ -422,7 +422,7 @@ function loadPost(user, repo, branch, path, file, cb) {
         return !!(app.state.permissions && app.state.permissions.push);
       }
 
-      if (!_.jekyll(path, file)) return {
+      if (!_.hasMetadata(content)) return {
         raw_metadata: "",
         content: content,
         published: false,
@@ -442,7 +442,7 @@ function loadPost(user, repo, branch, path, file, cb) {
     cb(err, _.extend(post, {
       "sha": commit,
       "markdown": _.markdown(file),
-      "jekyll": _.jekyll(path, file),
+      "jekyll": _.hasMetadata(data),
       "repo": repo,
       "path": path,
       "file": file,

--- a/_includes/util.js
+++ b/_includes/util.js
@@ -83,6 +83,11 @@ _.jekyll = function(path, file) {
   return !!(path.match('_posts') && _.markdown(file));
 };
 
+// check if a given file has YAML frontmater
+// -------
+_.hasMetadata = function(content) {
+  return content.match( /^(---\n)((.|\n)*?)\n---\n?/ );
+}
 
 // Extract file extension
 // -------


### PR DESCRIPTION
This allows proper metadata detection of YAML front matter on jekyll pages, as well as non-markdown files such as having YAML front matter on an HTML template.

Adds function _hasMetadata to utils, and uses the same YAML frontmater regex to detect'
