### PR TITLE
Diff for new files should be all green.

### DIFF
--- a/_includes/views/post.js
+++ b/_includes/views/post.js
@@ -42,12 +42,12 @@ views.Post = Backbone.View.extend({
     if (this.metadataEditor) this.model.raw_metadata = this.metadataEditor.getValue();
     if (!this.$('.button.save').hasClass('saving')) {
       this.$('.button.save').html(this.model.writeable ? "SAVE" : "SEND PATCH");
-      this.$('.button.save').removeClass('inactive error');      
+      this.$('.button.save').removeClass('inactive error');
     }
   },
 
   showDiff: function() {
-    var text1 = this.prevContent;
+    var text1 = this.model.persisted ? this.prevContent : '';
     var text2 = this.serialize();
     var d = this.dmp.diff_main(text1, text2);
     this.dmp.diff_cleanupSemantic(d);
@@ -57,13 +57,13 @@ views.Post = Backbone.View.extend({
 
   _toggleCommit: function() {
     if (!this.$('.document-menu').hasClass('commit')) {
-      this.$('.commit-message').val("Updated "+$('input.filepath').val());  
+      this.$('.commit-message').val("Updated "+$('input.filepath').val());
     }
 
     this.hideMeta();
     this.$('.button.save').html(this.$('.document-menu').hasClass('commit') ? (this.model.writeable ? "SAVE" : "SEND PATCH") : "COMMIT");
     this.$('.button.save').toggleClass('confirm');
-    this.$('.document-menu').toggleClass('commit');    
+    this.$('.document-menu').toggleClass('commit');
     this.$('.button.cancel-save').toggle();
     this.$('.document-menu-content .options').hide();
     this.showDiff();
@@ -192,7 +192,7 @@ views.Post = Backbone.View.extend({
 
   updateFilename: function(filepath, cb) {
     var that = this;
-    
+
     if (!_.validPathname(filepath)) return cb('error');
     app.state.path = this.model.path; // ?
     app.state.file = _.extractFilename(filepath)[1];
@@ -241,7 +241,7 @@ views.Post = Backbone.View.extend({
 
         patchFile(app.state.user, app.state.repo, app.state.branch, filepath, filecontent, message, function(err) {
           if (err) {
-            _.delay(function() { 
+            _.delay(function() {
               that.$('.button.save').html("SEND PATCH");
               that.$('.button.save').removeClass('error');
               that.$('.button.save').addClass('inactive');


### PR DESCRIPTION
When saving a new file, the diff should be all green (only added text).  The diff looks weird when it shows the sample text.

![before](https://f.cloud.github.com/assets/11674/141336/2c0d4928-7245-11e2-85ca-4da67a63edc5.png)

All green is much better.  \o/

![after](https://f.cloud.github.com/assets/11674/141344/85db3cc6-7245-11e2-9ad6-2378605c25c7.png)
