### PR TITLE
file path filter tweaks, fixes #254

### DIFF
--- a/_includes/model.js
+++ b/_includes/model.js
@@ -161,8 +161,6 @@ function loadBranches(user, repo, cb) {
 // -------
 
 function getFiles(tree, path, searchstr) {
-  debugger;
-
   var pathMatches = 0;
   function matchesPath(file) {
     if (file.path === path) return false; // skip current path


### PR DESCRIPTION
- Append trailing slash to `path` so that `_posts/a` directory path will no longer match `_posts/articles` (displaying `rticles`).
  - Should trailing slash only be appended if not already present?
- Only mark filenames if `searchstr` has a length.
  - Should mark be `<strong></strong>` instead of `<b></b>`?
