### PR TITLE
fix folder scope #302

### DIFF
--- a/_includes/model.js
+++ b/_includes/model.js
@@ -171,7 +171,7 @@ function getFiles(tree, path, searchstr) {
     }
     var match = file.path.match(new RegExp("^"+path+"(.*)$"));
     if (match) {
-      return !!searchstr || match[1].split('/').length <= (path ? 2 : 1);
+      return !!searchstr || match[1].split('/').length <= 1;
     }
     return false;
   }


### PR DESCRIPTION
trailing slash now included in `path` instead of in `match`

cc @dhcole @tristen @michael 
