### PR TITLE
Add translation options for posts

### DIFF
--- a/_includes/model.js
+++ b/_includes/model.js
@@ -374,6 +374,7 @@ function movePost(user, repo, branch, path, newPath, cb) {
 // Prepare new empty post
 
 function emptyPost(user, repo, branch, path, cb) {
+  var file = new Date().format("Y-m-d")+"-your-filename.md";
   var rawMetadata = "layout: default\npublished: false";
   var metadata = {
     "layout": "default",
@@ -398,6 +399,13 @@ function emptyPost(user, repo, branch, path, cb) {
     }
   }
 
+
+  // If ?file= in path, use it as file name
+  if (path.indexOf('?file=') !== -1) {
+    file = path.split('?file=')[1];
+    path = path.split('?file=')[0].replace(/\/$/, '');
+  }
+
   cb(null, {
     "metadata": metadata,
     "raw_metadata": rawMetadata,
@@ -407,7 +415,7 @@ function emptyPost(user, repo, branch, path, cb) {
     "published": false,
     "persisted": false,
     "writeable": true,
-    "file": new Date().format("Y-m-d")+"-your-filename.md"
+    "file": file
   });
 }
 

--- a/_includes/styles/style.css
+++ b/_includes/styles/style.css
@@ -1155,7 +1155,7 @@ ul.site li a {
   position: absolute;
   top: 60px;
   right: 0px;
-  width: 300px;
+  width: 231px;
   z-index: 3000;
   border-radius: 0 0 5px 5px;
   }
@@ -1167,7 +1167,7 @@ ul.site li a {
 
 .document-menu .options .actions {
   background: rgba(255, 255, 255, 0.1);
-  padding: 20px;
+  padding: 10px 20px;
   border-radius: 0 0 5px 5px;
   }
 
@@ -1178,6 +1178,7 @@ ul.site li a {
   -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
   border-radius: 5px;
+  margin: 10px 0;
   }
 
 .document-menu .options .actions .button:hover {
@@ -1689,15 +1690,20 @@ ul.site li a {
   font-weight: 700;
   }
 
+#notification .buttons {
+  margin: 0px auto;
+  text-align: center;
+  }
+
 #notification a {
 	background: #516066;
   padding: 5px;
   color: white;
   position: relative;
-  display: block;
+  display: inline-block;
   width: 100px;
   height: 30px;
-  margin: 0px auto;
+  margin: 0 5px;
   -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
   border-radius: 5px;
@@ -1706,7 +1712,9 @@ ul.site li a {
   font-size: 11px;
   font-weight: 700;
   }
+  #notification a.muted { background: #738890; }
   #notification a:hover { background: #3d4548; }
+
 
 ul.form li {
   position: relative;

--- a/_includes/templates/notification._
+++ b/_includes/templates/notification._
@@ -7,5 +7,8 @@
   <div class="notification <%= type %>">
     <%= message%> 
   </div>
-  <a class="button" href="../">Go back </a>
+  <div class="buttons">
+    <a class="button create" href="#">Create it </a>
+    <a class="button muted" href="../">Go back </a>
+  </div>
 <% } %>

--- a/_includes/templates/post._
+++ b/_includes/templates/post._
@@ -41,6 +41,13 @@
         </div>
       <% } %>
       <div class="actions">
+        <% if (app.state.config && app.state.config.languages) { %>
+        <% _(app.state.config.languages).each(function(lang) { %>
+        <% if (metadata.lang && metadata.lang !== lang.key) { %>
+        <a class="toggle translate button" href="#<%= lang.key %>">Translate to <%= lang.name %></a>
+        <% } %>
+        <% }); %>
+        <% } %>
         <a class="toggle delete button" href="#">Delete File</a>
       </div>
     </div>

--- a/_includes/views/application.js
+++ b/_includes/views/application.js
@@ -8,7 +8,8 @@ views.Application = Backbone.View.extend({
   // ------
 
   events: {
-    'click .toggle-view': 'toggleView'
+    'click .toggle-view': 'toggleView',
+    'click #notification .create': 'createPost'
   },
 
   toggleView: function (e) {
@@ -22,6 +23,16 @@ views.Application = Backbone.View.extend({
     link.addClass('active');
     router.navigate(route, true);
   },
+
+  createPost: function(e) {
+    var hash = window.location.hash.split('/');
+    hash[2] = 'new';
+    hash[hash.length - 1] = '?file=' + hash[hash.length - 1];
+
+    router.navigate(_(hash).compact().join('/'), true);
+    return false;
+  },
+
 
   // Initialize
   // ----------

--- a/_includes/views/post.js
+++ b/_includes/views/post.js
@@ -13,6 +13,7 @@ views.Post = Backbone.View.extend({
     'change input': '_makeDirty',
     'change #post_published': 'updateMetaData',
     'click .delete': '_delete',
+    'click .translate': '_translate',
     'click .toggle-options': '_toggleOptions'
   },
 
@@ -28,6 +29,24 @@ views.Post = Backbone.View.extend({
         router.navigate([app.state.user, app.state.repo, "tree", app.state.branch].join('/'), true);
       }, this));
     }
+    return false;
+  },
+
+  _translate: function(e) {
+    var hash = window.location.hash.split('/'),
+        href = $(e.currentTarget).attr('href').substr(1);
+
+    // If current page is not english and target page is english
+    if (href === 'en') {
+      hash.splice(-2, 2, hash[hash.length - 1]);
+    // If current page is english and target page is not english
+    } else if (this.model.metadata.lang === 'en') {
+      hash.splice(-1, 1, href, hash[hash.length - 1]);      
+    // If current page is not english and target page is not english
+    } else {
+      hash.splice(-2, 2, href, hash[hash.length - 1]);
+    }
+    router.navigate(_(hash).compact().join('/'), true);
     return false;
   },
 
@@ -366,7 +385,7 @@ views.Post = Backbone.View.extend({
 
   render: function() {
     var that = this;
-    $(this.el).html(templates.post(_.extend(this.model, { mode: this.mode })));
+    $(this.el).html(templates.post(_.extend(this.model, { mode: this.mode, metadata: jsyaml.load(this.model.raw_metadata) })));
     if (this.model.published) $(this.el).addClass('published');
     this.initEditor();
     return this;


### PR DESCRIPTION
Optional translation interface for posts. To use, add language options in `_config.yml`:

``` yml
languages:
  - name: 'English'
    key: 'en'
  - name: 'Español'
    key: 'es'
  - name: 'Français'
    key: 'fr'
```

Set each post's language with in its frontmatter, like `lang: en`, and save posts with the same file name into a subdirectory based on their language code:

```
/_posts/2013-01-01-post-title.md
/_posts/es/2013-01-01-post-title.md
/_posts/fr/2013-01-01-post-title.md
```
