### PR TITLE
stashFile on post.remove

### DIFF
--- a/src/prose/views/post.js
+++ b/src/prose/views/post.js
@@ -965,7 +965,9 @@ module.exports = Backbone.View.extend({
       }
     },
 
-    remove: function () {
+    remove: function() {
+      this.stashFile();
+
       this.eventRegister.unbind('edit', this.postViews);
       this.eventRegister.unbind('preview', this.preview);
       this.eventRegister.unbind('deleteFile', this.deleteFile);
@@ -979,7 +981,7 @@ module.exports = Backbone.View.extend({
       // Clear any file state classes in #prose
       this.eventRegister.trigger('updateSaveState', '', '');
 
-      $(window).unbind('pagehide');
+      $(window).off('pagehide');
       Backbone.View.prototype.remove.call(this);
     }
 });


### PR DESCRIPTION
`stashFile` was previously only called on `pagehide` (triggered when switching tabs, refreshing or closing a window). Since `sessionStorage` is being used instead of `localStorage`, changes will NOT persist through closing the window and opening a new window, but WILL persist through page refreshes or reloads. This patch adds a call to `stashFile` when the `post` view is removed, allowing changes to persist through navigation events.
#384 An exit warning is displayed when the user attempts to close or refresh the page, although content will be saved on refresh. Exit warning should not be necessary on `post` view removal, as `stashFile` saves content to `sessionStorage` now.
#386 Implementation completed.
