### PR TITLE
add button to view _drafts if repo is jailed to rooturl

### DIFF
--- a/templates/sidebarProject.html
+++ b/templates/sidebarProject.html
@@ -13,7 +13,7 @@
 <% var rooturl = (app.state.config && app.state.config.prose) ? app.state.config.prose.rooturl : undefined; %>
 <% if (rooturl && path != '_drafts') { %>
   <div class='inner'>
-    <a class='button' href='#<%= [user, repo, "tree", branch, "_drafts"].join("/") %>'>Drafts</a>
+    <a class='button round' href='#<%= [user, repo, "tree", branch, "_drafts"].join("/") %>'>View Drafts</a>
   </div>
 <% } %>
 


### PR DESCRIPTION
Simply adds a button on the sidebar that links to the _drafts folder. Only shows up if a `rooturl` is specified in prose settings, and if not already at /_drafts.

/cc @tristen 
