### PR TITLE
don't render hidden default metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "keymaster": "git://github.com/madrobby/keymaster.git#ddcb72eceb033db",
     "marked": "~0.2.8",
     "queue-async": "~1.0.3",
-    "diff": "~1.0.4"
+    "diff": "~1.0.4",
+    "deepmerge": "~0.2.7"
   },
   "devDependencies": {
     "mocha": "~1.9.0",

--- a/src/prose/views/post.js
+++ b/src/prose/views/post.js
@@ -1,6 +1,7 @@
 var $ = require('jquery-browserify');
 var chosen = require('chosen-jquery-browserify');
 var _ = require('underscore');
+_.merge = require('deepmerge');
 var jsyaml = require('js-yaml');
 var key = require('keymaster');
 var marked = require('marked');
@@ -742,7 +743,7 @@ module.exports = Backbone.View.extend({
             case 'hidden':
               tmpl = {};
               tmpl[data.name] = data.field.value;
-              view.model.metadata = _.defaults(view.model.metadata, tmpl);
+              view.model.metadata = _.merge(tmpl, view.model.metadata);
               break;
           }
         } else {


### PR DESCRIPTION
Set default metadata using _.defaults instead of writing to value attribute of hidden fields, return extended (modified) metadata from `getValue` rather than creating a new object.

@dhcole 
