### PR TITLE
Provide support for blocks of content defined as textarea in configurati...

### DIFF
--- a/src/prose/util.js
+++ b/src/prose/util.js
@@ -5,6 +5,13 @@ var marked = require('marked');
 var queue = require('queue-async');
 var chrono = require('chrono');
 
+// Cleans up a string for use in urls
+// -------
+_.stringToUrl = function(string) {
+  return string.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+},
+
+
 // Run an array of functions in serial
 // -------
 

--- a/templates/textarea.html
+++ b/templates/textarea.html
@@ -1,0 +1,4 @@
+<div class='form-item yaml-block'>
+  <label for='<%= name %>'><%= label %></label>
+  <textarea id='<%= id %>' type='text' name='<%= name %>' data-type='<%= type %>'><%= value %></textarea>
+</div>


### PR DESCRIPTION
This touches on #487. One thing to note is the output of the frontmatter is still a string. Not sure I see a way here to format this block as:

```
content: |
    Content here.
```

We could hold off on merging this in or punt on this for now.
