### PR TITLE
Make access to private repos optional

### DIFF
--- a/app/views/app.js
+++ b/app/views/app.js
@@ -55,7 +55,9 @@ module.exports = Backbone.View.extend({
   },
 
   render: function() {
-    this.$el.html(_.template(this.template, {}, { variable: 'data' }));
+    this.$el.html(_.template(this.template, {
+      login: config.site + '/login/oauth/authorize?client_id=' + config.id + '&scope=repo'
+    }, { variable: 'data' }));
 
     this.loader.setElement(this.$el.find('#loader')).render();
     this.sidebar.setElement(this.$el.find('#drawer')).render();

--- a/app/views/nav.js
+++ b/app/views/nav.js
@@ -25,7 +25,7 @@ module.exports = Backbone.View.extend({
 
   render: function() {
     this.$el.html(_.template(this.template, {
-      login: config.site + '/login/oauth/authorize?client_id=' + config.id + '&scope=repo'
+      login: config.site + '/login/oauth/authorize?client_id=' + config.id + '&scope=public_repo'
     }, { variable: 'data' }));
 
     this.$save = this.$el.find('.file .save .popup');

--- a/templates/app.html
+++ b/templates/app.html
@@ -11,6 +11,7 @@
       <li><a class='about' href='./#about'><%= t('navigation.about') %></a></li>
       <li><a class='help' href='https://github.com/prose/prose'><%= t('navigation.develop') %></a></li>
       <li><a href='./#chooselanguage'><%= t('navigation.language') %></a></li>
+      <li><a href='<%= data.login %>'><%= t('navigation.private_repo') %></a></li>
       <li class='divider authenticated'></li>
       <li class='authenticated'>
         <a href='#' class='logout'><%= t('navigation.logout') %></a>

--- a/templates/start.html
+++ b/templates/start.html
@@ -3,6 +3,6 @@
   <div class='inner'>
     <p><%= t('main.start.content') %></p>
     <p><a href='#about'><%= t('main.start.learn') %></a></p>
-    <a class='round button' href='<%= auth.site %>/login/oauth/authorize?client_id=<%= auth.id %>&scope=repo'><%= t('login') %></a>
+    <a class='round button' href='<%= auth.site %>/login/oauth/authorize?client_id=<%= auth.id %>&scope=public_repo'><%= t('login') %></a>
   </div>
 </div>

--- a/translations/application.yaml
+++ b/translations/application.yaml
@@ -16,6 +16,7 @@ en:
     develop: "Developers"
     logout: "Logout"
     language: "Language"
+    private_repo: "Authorize private repos"
   toolbar:
     heading: "Heading"
     subHeading: "Sub Heading"


### PR DESCRIPTION
Since I try Prose I want to keep my private repos outside this cool editor. The new GitHub API allow to give access only to public repos so I make the following changes:

* Login with public repos by default
* Add link on dropdown menu for requests access to private repos

I hope this workflow will fit in prose app.

Related issues: #126, #444