### PR TITLE
fix bug : "freeze when user click `drafts to posts`"

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -172,7 +172,7 @@ module.exports = Backbone.View.extend({
     path = path.replace(/^(_drafts)/, '_posts');
     var nearestDir = /\/?(?!.*\/).*$/;
 
-    while (!_.has(defaults, path) && nearestDir.test(path)) {
+    while (!_.has(defaults, path) && nearestDir.test(path) && path) {
       path = path.replace( nearestDir, '' );
     }
 


### PR DESCRIPTION
When you use `this.model && {}`  condition, this will always true. 

For example:

```
if ({}){
   alert("true");
}
```

will print true in your browser.

So `nearestPath` method  will loop infinitely and freeze  user browser.

This patch is just a workaround to fix the condition to use `nearestPath` normally. I don't know whether  it breaks other functions or not. 
