### PR TITLE
Corrected translation to image:'Insert Image'

### DIFF
--- a/translations/locales/en.json
+++ b/translations/locales/en.json
@@ -22,7 +22,7 @@
         "heading": "Heading",
         "subHeading": "Sub Heading",
         "link": "Insert Link",
-        "image": "Insert Link",
+        "image": "Insert Image",
         "bold": "Bold",
         "italic": "Italic",
         "blockquote": "Blockquote",


### PR DESCRIPTION
The Image button was translated with "Insert Link". This Commit fixes this to 'Insert Image'
