### PR TITLE
Copy metadata to fork

### DIFF
--- a/app/models/file.js
+++ b/app/models/file.js
@@ -278,7 +278,8 @@ module.exports = Backbone.Model.extend({
                   repo: repo,
                   sha: this.get('sha'),
                   message: this.get('message') || this.get('placeholder'),
-                  metadata: this.get('metadata')
+                  metadata: this.get('metadata'),
+                  defaults: this.get('defaults')
                 });
 
                 // Backbone expects these to be top level,


### PR DESCRIPTION
Copy parent blob metadata when fork is created. Ideally, this would be a clone, but not sure what other baggage we'd get then.

/cc @nschonni, fixes #618.
