### PR TITLE
Fix raw metadata editor redirection to index

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -1029,7 +1029,7 @@ module.exports = Backbone.View.extend({
       },
       path: path
     });
-    
+
     // Set default metadata for new path
     if (this.model && defaults) {
       this.model.set('defaults', defaults[this.nearestPath(path, defaults)]);
@@ -1214,7 +1214,7 @@ module.exports = Backbone.View.extend({
     // Loading State
     this.updateSaveState(t('actions.upload.uploading', { file: file.name }), 'saving');
 
-    // Default to media directory if defined in config, 
+    // Default to media directory if defined in config,
     // current directory if no path specified
     var dir = this.config.media ? this.config.media :
       util.extractFilename(this.model.get('path'))[0];

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -333,6 +333,16 @@ module.exports = Backbone.View.extend({
     this.stashApply();
   },
 
+  initMetadata: function() {
+    this.metadataEditor = new MetadataView({
+      model: this.model,
+      titleAsHeading: this.titleAsHeading(),
+      view: this
+    });
+
+    this.listenTo(this.metadataEditor.raw, 'change', this.makeDirty, this);
+  },
+
   keyMap: function() {
     var self = this;
 
@@ -469,12 +479,6 @@ module.exports = Backbone.View.extend({
   },
 
   renderMetadata: function() {
-    this.metadataEditor = new MetadataView({
-      model: this.model,
-      titleAsHeading: this.titleAsHeading(),
-      view: this
-    });
-
     this.metadataEditor.setElement(this.$el.find('#meta')).render();
     this.subviews['metadata'] = this.metadataEditor;
   },
@@ -501,6 +505,7 @@ module.exports = Backbone.View.extend({
       // initialize the subviews
       this.initEditor();
       this.initHeader();
+      this.initMetadata();
       this.initToolbar();
       this.initSidebar();
 
@@ -1029,7 +1034,7 @@ module.exports = Backbone.View.extend({
       },
       path: path
     });
-    
+
     // Set default metadata for new path
     if (this.model && defaults) {
       this.model.set('defaults', defaults[this.nearestPath(path, defaults)]);
@@ -1214,7 +1219,7 @@ module.exports = Backbone.View.extend({
     // Loading State
     this.updateSaveState(t('actions.upload.uploading', { file: file.name }), 'saving');
 
-    // Default to media directory if defined in config, 
+    // Default to media directory if defined in config,
     // current directory if no path specified
     var dir = this.config.media ? this.config.media :
       util.extractFilename(this.model.get('path'))[0];

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -333,16 +333,6 @@ module.exports = Backbone.View.extend({
     this.stashApply();
   },
 
-  initMetadata: function() {
-    this.metadataEditor = new MetadataView({
-      model: this.model,
-      titleAsHeading: this.titleAsHeading(),
-      view: this
-    });
-
-    this.listenTo(this.metadataEditor.raw, 'change', this.makeDirty, this);
-  },
-
   keyMap: function() {
     var self = this;
 
@@ -479,6 +469,12 @@ module.exports = Backbone.View.extend({
   },
 
   renderMetadata: function() {
+    this.metadataEditor = new MetadataView({
+      model: this.model,
+      titleAsHeading: this.titleAsHeading(),
+      view: this
+    });
+
     this.metadataEditor.setElement(this.$el.find('#meta')).render();
     this.subviews['metadata'] = this.metadataEditor;
   },
@@ -505,7 +501,6 @@ module.exports = Backbone.View.extend({
       // initialize the subviews
       this.initEditor();
       this.initHeader();
-      this.initMetadata();
       this.initToolbar();
       this.initSidebar();
 
@@ -1034,7 +1029,7 @@ module.exports = Backbone.View.extend({
       },
       path: path
     });
-
+    
     // Set default metadata for new path
     if (this.model && defaults) {
       this.model.set('defaults', defaults[this.nearestPath(path, defaults)]);
@@ -1219,7 +1214,7 @@ module.exports = Backbone.View.extend({
     // Loading State
     this.updateSaveState(t('actions.upload.uploading', { file: file.name }), 'saving');
 
-    // Default to media directory if defined in config,
+    // Default to media directory if defined in config, 
     // current directory if no path specified
     var dir = this.config.media ? this.config.media :
       util.extractFilename(this.model.get('path'))[0];

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -237,12 +237,11 @@ module.exports = Backbone.View.extend({
       theme: 'prose-bright'
     });
 
-    this.listenTo(this.raw, 'blur', (function(cm) {
-      var value = cm.getValue();
+    this.listenTo(this.raw, 'blur', (function() {
       var isChanged = false;
 
       try {
-        // Compare the current metadata to the new metadata
+        // Check if the metadata has changed after merging in the raw content.
         isChanged = !_.isEqual(this.model.get('metadata'), this.getValue());
       } catch(err) {
         console.log("Error parsing CodeMirror editor text");
@@ -250,6 +249,7 @@ module.exports = Backbone.View.extend({
       }
 
       // Only make the file dirty if the metadata has changed
+      // to avoid a blank commit.
       if (isChanged) {
         this.view.makeDirty();
       }

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -238,19 +238,17 @@ module.exports = Backbone.View.extend({
 
     this.listenTo(this.raw, 'blur', (function(cm) {
       var value = cm.getValue();
-      var raw;
+      var isChanged = false;
 
       try {
-        raw = jsyaml.safeLoad(value);
+        isChanged = !_.isEqual(this.model.get('metadata'), jsyaml.safeLoad(value));
       } catch(err) {
         console.log("Error parsing CodeMirror editor text");
         console.log(err);
       }
 
-      if (raw) {
-        var metadata = this.model.get('metadata');
-        this.model.set('metadata', _.extend(metadata, raw));
-
+      // Only make dirty if the metadata has changed
+      if (isChanged) {
         this.view.makeDirty();
       }
     }).bind(this));

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -274,9 +274,11 @@ module.exports = Backbone.View.extend({
 
     // Get the title value from heading if we need to.
     if (this.titleAsHeading) {
-      newMetadata.title = (this.view.header) ?
-        this.view.header.inputGet() :
-        metadata.title[0];
+      if (this.view.header) {
+        newMetadata.title = this.view.header.inputGet();
+      } else if (metadata && metadata.title) {
+        newMetadata.title = metadata.title;
+      }
     }
 
     // Load any data coming from a metafield (that has a name)

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -260,7 +260,17 @@ module.exports = Backbone.View.extend({
 
   getValue: function() {
     var view = this;
-    var metadata = this.model.get('metadata') || {};
+    var metadata = {};
+
+    // Load any data coming from not defined raw yaml front matter.
+    if (this.raw) {
+      try {
+        metadata = _.extend(metadata, jsyaml.safeLoad(this.raw.getValue()) || {});
+      } catch (err) {
+        console.log("Error parsing not defined raw yaml front matter");
+        console.log(err);
+      }
+    }
 
     if (this.view.toolbar &&
        this.view.toolbar.publishState() ||
@@ -336,16 +346,6 @@ module.exports = Backbone.View.extend({
         }
       }
     });
-
-    // Load any data coming from not defined raw yaml front matter.
-    if (this.raw) {
-      try {
-        metadata = _.merge(metadata, jsyaml.safeLoad(this.raw.getValue()) || {});
-      } catch (err) {
-        console.log("Error parsing not defined raw yaml front matter");
-        console.log(err);
-      }
-    }
 
     return metadata;
   },

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -263,10 +263,11 @@ module.exports = Backbone.View.extend({
     var metadata = this.model.get('metadata') || {};
     var newMetadata = {};
 
-    if (this.view.toolbar &&
-       this.view.toolbar.publishState() ||
+    // If the current published state is true then keep it that way
+    if (this.view.toolbar && this.view.toolbar.publishState() ||
        (metadata && metadata.published)) {
       newMetadata.published = true;
+    // Else default to unpublished state
     } else {
       newMetadata.published = false;
     }
@@ -275,10 +276,11 @@ module.exports = Backbone.View.extend({
     if (this.titleAsHeading) {
       newMetadata.title = (this.view.header) ?
         this.view.header.inputGet() :
-        this.model.get('metadata').title[0];
+        metadata.title[0];
     }
 
-    _.each(this.$el.find('[name]'), function(item) {
+    // Load any data coming from a metafield (that has a name)
+    _.each(this.$el.find('.metafield[name]'), function(item) {
       var $item = $(item);
       var value = $item.val();
 

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -197,15 +197,16 @@ module.exports = Backbone.View.extend({
   },
 
   updateModel: function(e) {
-    var target = e.currentTarget;
-    var key = target.name;
-    var value = target.value;
     var delta = {};
-    delta[key] = value;
+    var target = e.currentTarget;
+    var name = target.name;
+    var value = target.value;
 
-    var metadata = this.model.get('metadata');
-    this.model.set('metadata', _.extend(metadata, delta));
-    this.view.makeDirty();
+    if (name && value) {
+      delta[name] = value;
+      this.model.set('metadata', _.extend(this.model.get('metadata'), delta));
+      this.view.makeDirty();
+    }
   },
 
   rawKeyMap: function() {

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -11,7 +11,7 @@ module.exports = Backbone.View.extend({
   template: templates.metadata,
 
   events: {
-    'change .metafield': 'updateModel',
+    'change input': 'updateModel',
     'click .create-select': 'createSelect',
     'click .finish': 'exit'
   },

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -241,13 +241,14 @@ module.exports = Backbone.View.extend({
       var isChanged = false;
 
       try {
-        isChanged = !_.isEqual(this.model.get('metadata'), jsyaml.safeLoad(value));
+        // Compare the current metadata to the new metadata
+        isChanged = !_.isEqual(this.model.get('metadata'), this.getValue());
       } catch(err) {
         console.log("Error parsing CodeMirror editor text");
         console.log(err);
       }
 
-      // Only make dirty if the metadata has changed
+      // Only make the file dirty if the metadata has changed
       if (isChanged) {
         this.view.makeDirty();
       }

--- a/templates/meta/raw.html
+++ b/templates/meta/raw.html
@@ -2,6 +2,6 @@
   <label for='raw'><%= t('main.file.rawMeta') %></label>
   <% if (meta.help) { %><small><%= meta.help %></small><% } %>
   <fieldset>
-    <div name='raw' id='raw' class='metafield inner'></div>
+    <div id='raw' class='metafield inner'></div>
   </fieldset>
 </div>

--- a/templates/meta/raw.html
+++ b/templates/meta/raw.html
@@ -2,6 +2,6 @@
   <label for='raw'><%= t('main.file.rawMeta') %></label>
   <% if (meta.help) { %><small><%= meta.help %></small><% } %>
   <fieldset>
-    <div id='raw' class='metafield inner'></div>
+    <div id='raw' class='inner'></div>
   </fieldset>
 </div>


### PR DESCRIPTION
Fixes issues #623, and #627 which were causing redirection to the index page when using the raw metadata editor.

Also fixes it so that metadata removed from the raw metadata editor will also be removed in the commit, before it was leaving it in.