### PR TITLE
Avoid navigating to new path when saving new file

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -1145,17 +1145,6 @@ module.exports = Backbone.View.extend({
         var name = util.extractFilename(old)[1];
         var pathChange = path !== old;
 
-        // Navigate to edit path for new files
-        if (!model.previous('sha') || pathChange) {
-          this.router.navigate(_.compact([
-            this.repo.get('owner').login,
-            this.repo.get('name'),
-            'edit',
-            this.collection.branch.get('name'),
-            model.get('path')
-          ]).join('/'));
-        }
-
         // Remove old file if renamed
         // TODO: remove this when Repo Contents API supports renaming
         if (model.previous('sha') && pathChange) {


### PR DESCRIPTION
Saving already calls `this.edit()` on the file view, which updates the url, https://github.com/rebelzach/prose/blob/fix-new-file-back-button/app/views/file.js#L586 I believe removing this will prevent adding another link to the history, Clicking back from a new document should show the containing tree
