### PR TITLE
Fix an exception thrown when clicking the heading toolbar buttons twice.

### DIFF
--- a/app/views/toolbar.js
+++ b/app/views/toolbar.js
@@ -409,7 +409,7 @@ module.exports = Backbone.View.extend({
 
   heading: function(s) {
     if (s.charAt(0) === '#' && s.charAt(2) !== '#') {
-      this.view.editor.replaceSelection(_.lTrim(s.replace(/#/g, '')));
+      this.view.editor.replaceSelection(util.lTrim(s.replace(/#/g, '')));
     } else {
       this.view.editor.replaceSelection('## ' + s.replace(/#/g, ''));
     }
@@ -417,7 +417,7 @@ module.exports = Backbone.View.extend({
 
   subHeading: function(s) {
     if (s.charAt(0) === '#' && s.charAt(3) !== '#') {
-      this.view.editor.replaceSelection(_.lTrim(s.replace(/#/g, '')));
+      this.view.editor.replaceSelection(util.lTrim(s.replace(/#/g, '')));
     } else {
       this.view.editor.replaceSelection('### ' + s.replace(/#/g, ''));
     }


### PR DESCRIPTION
You can reproduce this by clicking either the h2 or h3 toolbar buttons twice. I believe this is just a typo.
