### PR TITLE
Add additional title attributes to links for enhanced screen reader acce...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prose",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "[Prose](http://prose.io) is a web-based interface for managing text-based content in your GitHub repositories. Use it to create, edit, and delete files, and save your changes directly to GitHub.",
   "dependencies": {
     "jquery-browserify": "~1.8.1",

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -6,31 +6,31 @@
 
 <ul class='file nav clearfix'>
   <li>
-    <a href='#' class='ico round pencil edit' data-state='edit'>
+    <a href='#' title="<%= t('navigation.edit') %>" class='ico round pencil edit' data-state='edit'>
       <span class='popup round arrow-right'><%= t('navigation.edit') %></span>
     </a>
   </li>
 
   <li>
-    <a href='#' class='ico round eye blob preview' data-state='blob'>
+    <a href='#' title="<%= t('navigation.preview') %>" class='ico round eye blob preview' data-state='blob'>
       <span class='popup round arrow-right'><%= t('navigation.preview') %></span>
     </a>
   </li>
 
   <li>
-    <a href='#' class='ico round metadata meta' data-state='meta'>
+    <a href='#' title="<%= t('navigation.meta') %>" class='ico round metadata meta' data-state='meta'>
       <span class='popup round arrow-right'><%= t('navigation.meta') %></span>
     </a>
   </li>
 
   <li>
-    <a href='#' class='ico round sprocket settings' data-state='settings' data-drawer=true>
+    <a href='#' title="<%= t('navigation.settings') %>" class='ico round sprocket settings' data-state='settings' data-drawer=true>
       <span class='popup round arrow-right'><%= t('navigation.settings') %></span>
     </a>
   </li>
 
   <li>
-    <a href='#' class='ico round save' data-state='save'>
+    <a href='#' title="<%= t('navigation.save') %>" class='ico round save' data-state='save'>
       <div class='status'></div>
       <span class='popup round arrow-right'>
         <%= t('navigation.save') %>
@@ -41,7 +41,7 @@
 
 <ul class='auth nav clearfix'>
   <li>
-    <a class='ico round switch login' href='<%= data.login %>'>
+    <a class='ico round switch login' href='<%= data.login %>' title="<%= t('login') %>">
       <span class='popup round arrow-right'><%= t('login') %></span>
     </a>
   </li>

--- a/templates/sidebar/save.html
+++ b/templates/sidebar/save.html
@@ -4,7 +4,7 @@
 <div class='inner authoring'>
   <div class='commit'>
     <textarea class='commit-message' placeholder></textarea>
-    <a class='ico small cancel round' href='#' data-action='cancel'>
+    <a class='ico small cancel round' title="<%= t('sidebar.save.cancel') %>" href='#' data-action='cancel'>
       <span class='popup round arrow-bottom'><%= t('sidebar.save.cancel') %></span>
     </a>
   </div>


### PR DESCRIPTION
...ssibility.

Unfortunately, screen readers don't like links of the form <a><span>Link text here</span></a>, or especially <a><div class="somearea"></div><span>Link text here</span></a>. There's no way to guess the link text.

I added title attributes to a few links to make them slightly more accessible.

I think I've done what is needed to suggest deploying this PR to prose.io. I'd really appreciate it if it could be, since it helps some with accessibility.

Thanks.
