### PR TITLE
Use textarea for editor, vastly improves accessibility.

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -289,10 +289,11 @@ module.exports = Backbone.View.extend({
   initEditor: function() {
     var lang = this.model.get('lang');
 
+    var code = this.$el.find('#code')[0];
+    code.value = this.model.get('content') || '';
     // TODO: set default content for CodeMirror
-    this.editor = CodeMirror(this.$el.find('#code')[0], {
+    this.editor = CodeMirror.fromTextArea(code, {
       mode: lang,
-      value: this.model.get('content') || '',
       lineWrapping: true,
       lineNumbers: (lang === 'gfm' || lang === null) ? false : true,
       extraKeys: this.keyMap(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prose",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "[Prose](http://prose.io) is a web-based interface for managing text-based content in your GitHub repositories. Use it to create, edit, and delete files, and save your changes directly to GitHub.",
   "dependencies": {
     "jquery-browserify": "~1.8.1",

--- a/templates/file.html
+++ b/templates/file.html
@@ -17,7 +17,7 @@
         </div>
       </div>
       <div id='drop' class='drop-mask'></div>
-      <div id='code' class='code round inner'></div>
+      <textarea id='code' class='code round inner'></textarea>
     </div>
     <div id='preview' class='view preview prose'></div>
   </div>


### PR DESCRIPTION
Using a div tag for your editor causes a number of accessibility issues:
- The area is not reported as a text area to access technologies. As such, that it can be edited is not obvious.
- Arrowing around does not provide meaningful feedback. For instance, the up and down arrows don't speak the newly-reached line.
- CodeMirror eats the tab key, making keyboard navigation off of the field impossible. Screen readers generally offer keystrokes to bypass a field's key handler so something that normally consumes navigation keys can be exited, but this only works on form fields.

I've replaced the div with a textarea. The alternative is maintaining code that duplicates the accessibility functionality of textarea, which is a huge mess.

In preliminary testing, this vastly improves the accessibility of Prose. Whereas before the editor control was very hit-or-miss and gave poor feedback, I'm now able to edit documents much more easily.

I myself am blind, so the one area I can't help with is appearance. I left the existing CSS class intact, but I leave it to your visual designers to tweak the appearance.

Perhaps this seems like a small thing, but you really do set yourselves up for worlds of hurt when you swap out a textarea with a div. The arrows are just one case that isn't covered. Backspace and Delete don't speak the character that was erased. Selection commands don't provide spoken feedback as to what gets selected. Go with a div and you'll need to write all this custom key handling, and I promise you won't handle it in the same way screen readers do, which will cause confusion. :) The work to restyle the textarea is vastly easier.
