### PR TITLE
Gulp Build: Use Gulp to build project.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "mocha-phantomjs": "~3.3.2",
     "phantomjs": "~1.9.7-4",
     "request": "~2.16.2",
-    "uglify-js": "~2.2.5"
+    "uglify-js": "~2.2.5",
+    "vinyl-source-stream": "^0.1.1"
   },
   "scripts": {
     "test": "make && node_modules/.bin/mocha-phantomjs test/index.html"


### PR DESCRIPTION
I've created the `gulpfile.js` build file porting the functionality from `Makefile` as is proposed in #702.

There are still a couple of tasks that are using the original shell command from `Makefile`, but they can slowly be improved.

To build the project we've to issue the following commands.

``` bash
$ npm install
$ gulp
```

Also, I've added a `watch` task to rebuild app files when they change.

``` bash
$ gulp watch
```
