### PR TITLE
Make it easier to rename files

### DIFF
--- a/app/util.js
+++ b/app/util.js
@@ -257,12 +257,6 @@ module.exports = {
     return false;
   },
 
-  autoSelect: function($el) {
-    $el.on('click', function() {
-      $el.select();
-    });
-  },
-
   parseLinkHeader: function(xhr, options) {
     options = _.clone(options) || {};
 

--- a/app/views/sidebar/settings.js
+++ b/app/views/sidebar/settings.js
@@ -60,7 +60,6 @@ module.exports = Backbone.View.extend({
       variable: 'settings'
     }));
 
-    util.autoSelect(this.$el.find('input.filepath'));
     return this;
   }
 });


### PR DESCRIPTION
Auto-select actually makes it harder to use the file input box, and as currently implemented does not let a user click in the box to rename a file.

This solves this problem and is strictly deleting code.
