### PR TITLE
Ensure that we remove the old file when we rename

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -1222,13 +1222,13 @@ module.exports = Backbone.View.extend({
             error: (function(xhr, textStatus, errorThrown) {
               var res = JSON.parse(xhr.responseText);
               this.updateSaveState(res.message, 'error');
-            },
+            }).bind(this),
 
             // ensure we can make multiple path changes, and not just copy the file
             success: function(){
                 model.set('oldpath', path);
             }
-            ).bind(this)
+
           });
         }
         else if (pathChange){


### PR DESCRIPTION
Previously if you did 2 file renames in a row, you will not remove the previous file.

i.e.
1. rename a file
2. rename the same file again  (this will actually copy the file instead of renaming)
