### PR TITLE
Allow default filenames that do not contain dates.

### DIFF
--- a/app/views/header.js
+++ b/app/views/header.js
@@ -103,8 +103,13 @@ module.exports = Backbone.View.extend({
       var date = util.extractDate(name);
       var extension = name.split('.').pop();
 
-      path = parts.join('/') + '/' + date + '-' +
-        util.stringToUrl(value) + '.' + extension;
+      path = parts.join('/') + '/';
+
+      if(date){
+        path += date + '-';
+      }
+
+      path += util.stringToUrl(value) + '.' + extension;
 
       this.file.set('path', path);
     }


### PR DESCRIPTION
If we change the default filename to not contain a date, make sure we do not prepend a '-'.

This handles a more rare case, but in our use case we changed the default file name to not prepend a date, and this instead prepended a '-'.   It's up to you guys whether you think this is a reasonable option.
