### PR TITLE
Set image src/alt during drag/drop uploading

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -1247,6 +1247,14 @@ module.exports = Backbone.View.extend({
   },
 
   updateImageInsert: function(e, file, content) {
+    var path = (this.mediaDirectoryPath) ?
+                    this.mediaDirectoryPath :
+                    util.extractFilename(this.toolbar.file.attributes.path)[0];
+    var src = path + '/' + encodeURIComponent(file.name);
+
+    this.$el.find('input[name="url"]').val(src);
+    this.$el.find('input[name="alt"]').val('');
+
     this.toolbar.queue = {
       e: e,
       file: file,

--- a/app/views/toolbar.js
+++ b/app/views/toolbar.js
@@ -74,11 +74,6 @@ module.exports = Backbone.View.extend({
   fileInput: function(e) {
     var view = this;
     upload.fileSelect(e, function(e, file, content) {
-      var path = (view.mediaDirectoryPath) ? view.mediaDirectoryPath : util.extractFilename(view.file.attributes.path)[0];
-      var src = path + '/' + encodeURIComponent(file.name);
-
-      view.$el.find('input[name="url"]').val(src);
-      view.$el.find('input[name="alt"]').val('');
       view.trigger('updateImageInsert', e, file, content);
     });
 


### PR DESCRIPTION
Previously, the image src and alt attributes were only updated when
adding an image by selecting it. Now they are updated during drag/drop
as well.
