### PR TITLE
Travis shows build unknown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
 - '0.10'
+before_script:
+- npm install -g gulp
 notifications:
   email: false


### PR DESCRIPTION
Added before_script for travis to install gulp. This will tell travis to install gulp before running `npm test`.
