### PR TITLE
Changed to local gulp

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "vinyl-source-stream": "^0.1.1"
   },
   "scripts": {
-    "test": "gulp && node_modules/.bin/mocha-phantomjs test/index.html"
+    "test": "node_modules/.bin/gulp && node_modules/.bin/mocha-phantomjs test/index.html"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
[This comment](https://github.com/prose/prose/pull/753#issuecomment-54178860) suggested that we switch from `gulp` to `./node_modules/.bin/gulp` in the `test` script.
