### PR TITLE
Don't obscure splash screen with loading indicator

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -52,6 +52,7 @@ module.exports = Backbone.Router.extend({
     });
 
     this.app.render();
+    this.app.loader.done();
   },
 
   chooseLanguage: function() {


### PR DESCRIPTION
Call this.app.loader.done() at the end of AppView#initialize so that the loader is not obscuring the splash screen (that is, the one with the Authorize on Github button)
