### PR TITLE
404 Authorize button & Repository Scope

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -23,6 +23,10 @@ var ChooseLanguageView = require('./views/chooselanguage');
 var templates = require('../dist/templates');
 var util = require('./util');
 var auth = require('./config');
+var cookie = require('./cookie');
+
+// Set scope
+auth.scope = cookie.get('scope') || 'repo';
 
 module.exports = Backbone.Router.extend({
 
@@ -376,7 +380,7 @@ module.exports = Backbone.Router.extend({
       options.unshift({
         'title': t('login'),
         'link': auth.site + '/login/oauth/authorize?client_id=' +
-          auth.id + '&scope=repo&redirect_uri=' +
+          auth.id + '&scope=' + auth.scope + '&redirect_uri=' +
           encodeURIComponent(window.location.href)
       });
     }

--- a/app/router.js
+++ b/app/router.js
@@ -22,6 +22,7 @@ var ChooseLanguageView = require('./views/chooselanguage');
 
 var templates = require('../dist/templates');
 var util = require('./util');
+var auth = require('./config');
 
 module.exports = Backbone.Router.extend({
 
@@ -369,6 +370,16 @@ module.exports = Backbone.Router.extend({
         'link': '/'
       }
     ];
+
+    if (xhr.status === 404 && !this.user) {
+      error = t('notification.404');
+      options.unshift({
+        'title': t('login'),
+        'link': auth.site + '/login/oauth/authorize?client_id=' +
+          auth.id + '&scope=repo&redirect_uri=' +
+          encodeURIComponent(window.location.href)
+      });
+    }
 
     this.notify(message, error, options);
   }

--- a/app/views/nav.js
+++ b/app/views/nav.js
@@ -4,6 +4,10 @@ var Backbone = require('backbone');
 var config = require('../config');
 var utils = require('../util');
 var templates = require('../../dist/templates');
+var cookie = require('../cookie');
+
+// Set scope
+config.scope = cookie.get('scope') || 'repo';
 
 module.exports = Backbone.View.extend({
   template: templates.nav,
@@ -25,7 +29,9 @@ module.exports = Backbone.View.extend({
 
   render: function() {
     this.$el.html(_.template(this.template, {
-      login: config.site + '/login/oauth/authorize?client_id=' + config.id + '&scope=repo'
+      login: config.site + '/login/oauth/authorize' +
+        '?client_id=' + config.id + '&scope=' + config.scope + '&redirect_uri=' +
+        encodeURIComponent(window.location.href)
     }, { variable: 'data' }));
 
     this.$save = this.$el.find('.file .save .popup');

--- a/app/views/start.js
+++ b/app/views/start.js
@@ -3,14 +3,37 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var templates = require('../../dist/templates');
 var auth = require('../config');
+var cookie = require('../cookie');
+
+// Set scope
+auth.scope = cookie.get('scope') || 'repo';
 
 module.exports = Backbone.View.extend({
   id: 'start',
+
+  events: {
+    'click a[href="#scopes"]': 'toggleScope',
+    'change .toggle-hide select': 'setScope'
+  },
 
   template: templates.start,
 
   render: function() {
     this.$el.html(_.template(this.template, auth, { variable: 'auth' }));
     return this;
+  },
+
+  toggleScope: function(e) {
+    e.preventDefault();
+    this.$('.toggle-hide').toggleClass('show');
+  },
+
+  setScope: function(e) {
+    var scope = $(e.currentTarget).val(),
+        expire = new Date((new Date()).setYear((new Date()).getFullYear() + 20));
+    auth.scope = scope;
+    cookie.set('scope', scope, expire);
+    this.render();
+    router.app.nav.render();
   }
 });

--- a/style.css
+++ b/style.css
@@ -1679,6 +1679,17 @@ ins {
     display:block;
     }
 
+.toggle-hide select {
+  display: none;
+  }
+.toggle-hide.show select {
+  display: block;
+  }
+.toggle-hide a {
+  padding: 5px 0;
+  display: block;
+  }
+
 /* ------------------------------------------
   File /:filename
 ---------------------------------------------*/

--- a/templates/start.html
+++ b/templates/start.html
@@ -3,6 +3,13 @@
   <div class='inner'>
     <p><%= t('main.start.content') %></p>
     <p><a href='#about'><%= t('main.start.learn') %></a></p>
-    <a class='round button' href='<%= auth.site %>/login/oauth/authorize?client_id=<%= auth.id %>&scope=repo'><%= t('login') %></a>
+    <a class='round button' href='<%= auth.site %>/login/oauth/authorize?client_id=<%= auth.id %>&scope=<%- auth.scope %>'><%= t('login') %></a>
+    <div class="toggle-hide">
+      <a href="#scopes" class="deemphasize">Set repository access</a>
+      <select>
+        <option value="repo" <% if (auth.scope === 'repo') {%>selected<% } %>>Public and private repositories</option>
+        <option value="public_repo" <% if (auth.scope === 'public_repo') {%>selected<% } %>>Only public repositories</option>
+      </select>
+    </div>
   </div>
 </div>

--- a/translations/locales/en.json
+++ b/translations/locales/en.json
@@ -132,6 +132,7 @@
         "loginDescription": "Please login with your GitHub account to access that project.",
         "create": "Create it",
         "home": "Back to Main Page",
+        "404": "This file does not exist, or you don't have access to it. Try authorizing with GitHub.",
         "back": "Go Back",
         "githubStatus": "Status on GitHub ({status})",
         "error": {


### PR DESCRIPTION
Offer unauthenticated users the option to authorize to with GitHub on 404 errors. Redirects back to the original file after successful authentication.

![screenshot 2015-02-12 22 19 27](https://cloud.githubusercontent.com/assets/170641/6181719/3f466dbe-b305-11e4-8cbe-613d09f25363.png)

When users try to access a post in a private repository without authorizing first, GitHub's API returns a 404. This gives the user the option to authenticate and return to that page.
