### PR TITLE
Image URL Fix

### DIFF
--- a/app/views/toolbar.js
+++ b/app/views/toolbar.js
@@ -392,7 +392,7 @@ module.exports = Backbone.View.extend({
         // Finally, clear the queue object
         this.queue = undefined;
       } else {
-        var src = '{{site.baseurl}}/' + $('input[name="url"]').val();
+        var src = '{{site.baseurl}}' + $('input[name="url"]').val();
         var alt = $('input[name="alt"]').val();
         this.view.editor.replaceSelection('![' + alt + '](' + src + ')');
         this.view.editor.focus();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prose",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "[Prose](http://prose.io) is a web-based interface for managing text-based content in your GitHub repositories. Use it to create, edit, and delete files, and save your changes directly to GitHub.",
   "dependencies": {
     "backbone": "~1.0.0",


### PR DESCRIPTION
When adding an image URL with the toolbar it generated the link with a preceding '/'
this broke the image link.

Example:

/http://img.com/img.jpg
