### PR TITLE
Include _config.yml properties in config object

### DIFF
--- a/app/collections/files.js
+++ b/app/collections/files.js
@@ -89,10 +89,7 @@ module.exports = Backbone.Collection.extend({
       // Load _config.yml, set parsed value on collection
       // Extend to capture settings from outside config.prose
       // while allowing override
-      this.config = _.extend(config, {
-        baseurl: config.baseurl,
-        languages: config.languages
-      }, config.prose);
+      this.config = _.extend(config, config.prose);
 
       if (config.prose.ignore) {
         this.parseIgnore(config.prose.ignore);

--- a/app/collections/files.js
+++ b/app/collections/files.js
@@ -89,7 +89,7 @@ module.exports = Backbone.Collection.extend({
       // Load _config.yml, set parsed value on collection
       // Extend to capture settings from outside config.prose
       // while allowing override
-      this.config = _.extend({
+      this.config = _.extend(config, {
         baseurl: config.baseurl,
         languages: config.languages
       }, config.prose);

--- a/test/fixtures/metadata.js
+++ b/test/fixtures/metadata.js
@@ -6,8 +6,10 @@ module.exports.string = jsyaml.safeDump({
       _posts: [
         'date: CURRENT_DATETIME'
       ]
-    }
-  }
+    },
+    proseProp: true
+  },
+  configProp: true
 });
 
 module.exports.forms = jsyaml.safeDump({

--- a/test/spec/collections/files.js
+++ b/test/spec/collections/files.js
@@ -35,4 +35,15 @@ describe('files collection', function() {
     });
   });
 
+  it('Extends config object with config.prose settings', function(done) {
+    var files = fileCollectionMocker();
+    files.parseConfig(fileMocker(stringMeta), {
+      success: function() {
+        expect(files.config.proseProp).to.eql(true);
+        expect(files.config.configProp).to.eql(true);
+        done();
+      }
+    });
+  });
+
 });

--- a/vendor/liquid.patch.js
+++ b/vendor/liquid.patch.js
@@ -149,12 +149,12 @@ module.exports = function() {
   Liquid.Template.registerFilter({
     replace: function(input, string, replacement) {
       replacement = replacement || '';
-      return input.toString().split(string).join(replacement);
+      return input ? input.toString().split(string).join(replacement) : '';
     },
 
     replace_first: function(input, string, replacement) {
       replacement = replacement || '';
-      return input.toString().replace(string, replacement);
+      return input ? input.toString().replace(string, replacement) : '';
     }
   });
 }


### PR DESCRIPTION
This PR makes `_config.yml` properties available in the `site` object for previews. I thought this was already happening... it's possible it was overwritten somehow. 

It also includes a minor fix that prevents an error when an included file is empty.

Also, tests seem broken for an unrelated reason.