### PR TITLE
Fix undefined variable and shadowed variable

### DIFF
--- a/app/models/file.js
+++ b/app/models/file.js
@@ -268,7 +268,8 @@ module.exports = Backbone.Model.extend({
             repo.branches.fetch({
               cache: false,
               success: (function(collection, res, options) {
-                var branch = collection.findWhere({ name: branch });
+                collection = repo.branches;
+                branch = collection.findWhere({ name: branch });
 
                 // Create new File model in forked repo
                 // TODO: serialize metadata, set raw content

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -59,6 +59,7 @@ module.exports = Backbone.Model.extend({
         // TODO: Forking is async, retry if request fails
         repo.branches.fetch({
           success: (function(collection, res, options) {
+            collection = repo.branches;
             var prefix = 'prose-patch-';
 
             var branches = collection.filter(function(model) {


### PR DESCRIPTION
On Chromium 43, editing a file in someone else's repository then saving (which should trigger a fork then a pull request) doesn't work. 

I traced it back to the `collection` argument of the `success` callback of `repo.branches.fetch` being undefined. I only fixed it in a make-it-work-whatever kind of way, reinstating that value from elsewhere—I haven't worked on a Backbone app before and this is as far as I got. (Incidentally, is there a way of interacting with Backbone models of a living app from a command line? I'm used to interactive programming.)

Also, the call:

    var branch = collection.findWhere({ name: branch });

...was failing because the `branch` argument was undefined. The in-scope `branch` variable was being shadowed by the newly created `var branch`, and the latter was being passed as argument. 