### PR TITLE
Expose Backbone to allow using Backbone debugger

### DIFF
--- a/app/boot.js
+++ b/app/boot.js
@@ -5,6 +5,7 @@ var en = require('../dist/en.js');
 window.locale.en = en;
 window.locale.current('en');
 window.app = {};
+window.Backbone = Backbone;
 
 var $ = require('jquery-browserify');
 var _ = require('underscore');


### PR DESCRIPTION
This might help contributions: by exposing the Backbone object, it's possible to use the [Chrome Backbone debugger](https://chrome.google.com/webstore/detail/backbone-debugger/bhljhndlimiafopmmhjlgfpnnchjjbhd). (Related: Maluen/Backbone-Debugger#40)