### PR TITLE
Always define the config object

### DIFF
--- a/app/collections/files.js
+++ b/app/collections/files.js
@@ -85,6 +85,7 @@ module.exports = Backbone.Collection.extend({
       console.log(err);
     }
 
+    this.config = {};
     if (config && config.prose) {
       // Load _config.yml, set parsed value on collection
       // Extend to capture settings from outside config.prose


### PR DESCRIPTION
If there are no prose specific settings inside _config.yml or _prose.yml does not exist, then these lines from [app/views/file.js](https://github.com/prose/prose/blob/master/app/views/file.js#L1290-L1293)
```js
    // Default to media directory if defined in config,
    // current directory if no path specified
    var dir = this.config.media ? this.config.media :
      util.extractFilename(this.model.get('path'))[0];
```
give a fatal error because `this.config` is not defined.

The [parseConfig()](https://github.com/prose/prose/blob/master/app/collections/files.js#L77) function should at least create an empty config object.