### PR TITLE
Metadata fixes

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -835,11 +835,6 @@ module.exports = Backbone.View.extend({
       this.model.set('content', this.editor.getValue());
     }
 
-    // Update MetaData
-    if (this.metadataEditor) {
-      this.model.set('metadata', this.metadataEditor.getValue());
-    }
-
     var label = this.model.get('writable') ?
       t('actions.change.save') :
       t('actions.change.submit');

--- a/app/views/meta/button.js
+++ b/app/views/meta/button.js
@@ -7,7 +7,11 @@ module.exports = Backbone.View.extend({
 
   template: templates.meta.button,
 
-  render: function () {
+  initialize: function(options) {
+    this.name = options.data.name;
+  },
+
+  render: function() {
     var data = this.options.data;
     var button = {
       name: data.name,
@@ -17,8 +21,14 @@ module.exports = Backbone.View.extend({
       off: data.field.off
     };
 
-    return _.template(this.template, button, {
+    this.setElement($(_.template(this.template, button, {
       variable: 'meta'
-    });
+    })));
+    this.$form = this.$el.find('button');
+    return this.$el;
+  },
+
+  getValue: function() {
+    return this.$form.val() === 'true';
   }
 });

--- a/app/views/meta/button.js
+++ b/app/views/meta/button.js
@@ -1,0 +1,24 @@
+var $ = require('jquery-browserify');
+var Backbone = require('backbone');
+var _ = require('underscore');
+var templates = require('../../../dist/templates');
+
+module.exports = Backbone.View.extend({
+
+  template: templates.meta.button,
+
+  render: function () {
+    var data = this.options.data;
+    var button = {
+      name: data.name,
+      label: data.field.label,
+      help: data.field.help,
+      on: data.field.on,
+      off: data.field.off
+    };
+
+    return _.template(this.template, button, {
+      variable: 'meta'
+    });
+  }
+});

--- a/app/views/meta/button.js
+++ b/app/views/meta/button.js
@@ -6,6 +6,7 @@ var templates = require('../../../dist/templates');
 module.exports = Backbone.View.extend({
 
   template: templates.meta.button,
+  type: 'button',
 
   initialize: function(options) {
     this.name = options.data.name;
@@ -30,5 +31,9 @@ module.exports = Backbone.View.extend({
 
   getValue: function() {
     return this.$form.val() === 'true';
+  },
+
+  setValue: function(value) {
+    this.val(value);
   }
 });

--- a/app/views/meta/button.js
+++ b/app/views/meta/button.js
@@ -7,11 +7,17 @@ module.exports = Backbone.View.extend({
 
   template: templates.meta.button,
   type: 'button',
+  events: {
+    'click button': 'toggleState'
+  },
 
   initialize: function(options) {
     this.name = options.data.name;
+    this.on = options.data.field.on;
+    this.off = options.data.field.off;
   },
 
+  // default value is on, or true.
   render: function() {
     var data = this.options.data;
     var button = {
@@ -19,7 +25,8 @@ module.exports = Backbone.View.extend({
       label: data.field.label,
       help: data.field.help,
       on: data.field.on,
-      off: data.field.off
+      off: data.field.off,
+      value: data.field.on
     };
 
     this.setElement($(_.template(this.template, button, {
@@ -29,11 +36,19 @@ module.exports = Backbone.View.extend({
     return this.$el;
   },
 
-  getValue: function() {
-    return this.$form.val() === 'true';
+  toggleState: function() {
+    var val = this.$form.val() === this.on ?
+      this.off : this.on;
+    this.$form.val(val).text(val);
   },
 
+  getValue: function() {
+    return this.$form.val() === this.on;
+  },
+
+  // Sets value to false if user gives anything except
+  // the string equivalent of on.
   setValue: function(value) {
-    this.val(value);
+    this.$form.val(value === this.on);
   }
 });

--- a/app/views/meta/checkbox.js
+++ b/app/views/meta/checkbox.js
@@ -5,11 +5,8 @@ var templates = require('../../../dist/templates');
 
 module.exports = Backbone.View.extend({
 
-  events: {
-    'change .metafield': 'updateValue'
-  },
-
   template: templates.meta.checkbox,
+  type: 'checkbox',
 
   initialize: function(options) {
     this.name = options.data.name;
@@ -32,11 +29,11 @@ module.exports = Backbone.View.extend({
     return this.$el;
   },
 
-  updateValue: function() {
-    this.$form.val(this.$form[0].checked ? true : false);
-  },
-
   getValue: function() {
     return this.$form[0].checked;
-  }
+  },
+
+  setValue: function(value) {
+    this.$form[0].checked = value;
+  },
 });

--- a/app/views/meta/checkbox.js
+++ b/app/views/meta/checkbox.js
@@ -1,0 +1,24 @@
+var $ = require('jquery-browserify');
+var Backbone = require('backbone');
+var _ = require('underscore');
+var templates = require('../../../dist/templates');
+
+module.exports = Backbone.View.extend({
+
+  template: templates.meta.checkbox,
+
+  render: function () {
+    var data = this.options.data;
+    var checkbox = {
+      name: data.name,
+      label: data.field.label,
+      help: data.field.help,
+      value: data.name,
+      checked: data.field.value
+    };
+
+    return _.template(this.template, checkbox, {
+      variable: 'meta'
+    });
+  }
+});

--- a/app/views/meta/checkbox.js
+++ b/app/views/meta/checkbox.js
@@ -5,9 +5,17 @@ var templates = require('../../../dist/templates');
 
 module.exports = Backbone.View.extend({
 
+  events: {
+    'change .metafield': 'updateValue'
+  },
+
   template: templates.meta.checkbox,
 
-  render: function () {
+  initialize: function(options) {
+    this.name = options.data.name;
+  },
+
+  render: function() {
     var data = this.options.data;
     var checkbox = {
       name: data.name,
@@ -17,8 +25,18 @@ module.exports = Backbone.View.extend({
       checked: data.field.value
     };
 
-    return _.template(this.template, checkbox, {
+    this.setElement($(_.template(this.template, checkbox, {
       variable: 'meta'
-    });
+    })));
+    this.$form = this.$el.find('input');
+    return this.$el;
+  },
+
+  updateValue: function() {
+    this.$form.val(this.$form[0].checked ? true : false);
+  },
+
+  getValue: function() {
+    return this.$form[0].checked;
   }
 });

--- a/app/views/meta/multiselect.js
+++ b/app/views/meta/multiselect.js
@@ -1,0 +1,28 @@
+var $ = require('jquery-browserify');
+var Backbone = require('backbone');
+var _ = require('underscore');
+var templates = require('../../../dist/templates');
+
+module.exports = Backbone.View.extend({
+
+  template: templates.meta.multiselect,
+
+  // TODO write tests for alterable behavior.
+  // TODO write tests for multiselect behavior.
+  render: function () {
+    var data = this.options.data;
+    var multiselect = {
+      name: data.name,
+      label: data.field.label,
+      help: data.field.help,
+      alterable: data.field.alterable,
+      placeholder: data.field.placeholder,
+      options: data.field.options,
+      lang: data.lang
+    };
+
+    return _.template(this.template, multiselect, {
+      variable: 'meta'
+    });
+  }
+});

--- a/app/views/meta/multiselect.js
+++ b/app/views/meta/multiselect.js
@@ -7,6 +7,10 @@ module.exports = Backbone.View.extend({
 
   template: templates.meta.multiselect,
 
+  initialize: function(options) {
+    this.name = options.data.name;
+  },
+
   // TODO write tests for alterable behavior.
   // TODO write tests for multiselect behavior.
   render: function () {
@@ -21,8 +25,14 @@ module.exports = Backbone.View.extend({
       lang: data.lang
     };
 
-    return _.template(this.template, multiselect, {
+    this.setElement($(_.template(this.template, multiselect, {
       variable: 'meta'
-    });
+    })));
+    this.$form = this.$el.find('select');
+    return this.$el;
+  },
+
+  getValue: function() {
+    return this.$form.val();
   }
 });

--- a/app/views/meta/multiselect.js
+++ b/app/views/meta/multiselect.js
@@ -37,14 +37,22 @@ module.exports = Backbone.View.extend({
     return this.$form.val();
   },
 
-  // TODO add an option if not found
   setValue: function(value) {
     var values = _.isArray(value) ? value : [value];
     var $el = this.$el;
+    var $form = this.$form;
     _.each(values, function(v) {
-      $el.find('option[value="' + v + '"]').each(function() {
-        this.selected = 'selected';
-      });
+      var match = $el.find('option[value="' + v + '"]');
+      if (match.length) {
+        match.each(function() {
+          this.selected = 'selected';
+        });
+      }
+      // add the value as an option if none exists
+      else {
+        $form.append($('<option />', {checked: true, value: value, text: value}));
+        $form.trigger('liszt:updated');
+      }
     });
   }
 });

--- a/app/views/meta/multiselect.js
+++ b/app/views/meta/multiselect.js
@@ -6,6 +6,7 @@ var templates = require('../../../dist/templates');
 module.exports = Backbone.View.extend({
 
   template: templates.meta.multiselect,
+  type: 'multiselect',
 
   initialize: function(options) {
     this.name = options.data.name;
@@ -34,5 +35,16 @@ module.exports = Backbone.View.extend({
 
   getValue: function() {
     return this.$form.val();
+  },
+
+  // TODO add an option if not found
+  setValue: function(value) {
+    var values = _.isArray(value) ? value : [value];
+    var $el = this.$el;
+    _.each(values, function(v) {
+      $el.find('option[value="' + v + '"]').each(function() {
+        this.selected = 'selected';
+      });
+    });
   }
 });

--- a/app/views/meta/multiselect.js
+++ b/app/views/meta/multiselect.js
@@ -50,7 +50,9 @@ module.exports = Backbone.View.extend({
       }
       // add the value as an option if none exists
       else {
-        $form.append($('<option />', {checked: true, value: value, text: value}));
+        var $option = $('<option />', {value: v, text: v});
+        $option.appendTo($form);
+        $option.prop('selected', true);
         $form.trigger('liszt:updated');
       }
     });

--- a/app/views/meta/multiselect.js
+++ b/app/views/meta/multiselect.js
@@ -53,8 +53,8 @@ module.exports = Backbone.View.extend({
         var $option = $('<option />', {value: v, text: v});
         $option.appendTo($form);
         $option.prop('selected', true);
-        $form.trigger('liszt:updated');
       }
     });
+    $form.trigger('liszt:updated');
   }
 });

--- a/app/views/meta/select.js
+++ b/app/views/meta/select.js
@@ -6,6 +6,7 @@ var templates = require('../../../dist/templates');
 module.exports = Backbone.View.extend({
 
   template: templates.meta.select,
+  type: 'select',
 
   initialize: function(options) {
     this.name = options.data.name;
@@ -31,6 +32,16 @@ module.exports = Backbone.View.extend({
 
   getValue: function() {
     return this.$form.val();
-  }
+  },
 
+  // TODO add an option if not found
+  setValue: function(value) {
+    var values = _.isArray(value) ? value : [value];
+    var $el = this.$el;
+    _.each(values, function(v) {
+      $el.find('option[value="' + v + '"]').each(function() {
+        this.selected = 'selected';
+      });
+    });
+  }
 });

--- a/app/views/meta/select.js
+++ b/app/views/meta/select.js
@@ -7,6 +7,10 @@ module.exports = Backbone.View.extend({
 
   template: templates.meta.select,
 
+  initialize: function(options) {
+    this.name = options.data.name;
+  },
+
   render: function () {
     var data = this.options.data;
     var select = {
@@ -18,8 +22,15 @@ module.exports = Backbone.View.extend({
       lang: data.lang
     };
 
-    return _.template(this.template, select, {
+    this.setElement($(_.template(this.template, select, {
       variable: 'meta'
-    });
+    })));
+    this.$form = this.$el.find('select');
+    return this.$el;
+  },
+
+  getValue: function() {
+    return this.$form.val();
   }
+
 });

--- a/app/views/meta/select.js
+++ b/app/views/meta/select.js
@@ -1,0 +1,25 @@
+var $ = require('jquery-browserify');
+var Backbone = require('backbone');
+var _ = require('underscore');
+var templates = require('../../../dist/templates');
+
+module.exports = Backbone.View.extend({
+
+  template: templates.meta.select,
+
+  render: function () {
+    var data = this.options.data;
+    var select = {
+      name: data.name,
+      label: data.field.label,
+      help: data.field.help,
+      placeholder: data.field.placeholder,
+      options: data.field.options,
+      lang: data.lang
+    };
+
+    return _.template(this.template, select, {
+      variable: 'meta'
+    });
+  }
+});

--- a/app/views/meta/select.js
+++ b/app/views/meta/select.js
@@ -34,14 +34,22 @@ module.exports = Backbone.View.extend({
     return this.$form.val();
   },
 
-  // TODO add an option if not found
   setValue: function(value) {
     var values = _.isArray(value) ? value : [value];
     var $el = this.$el;
+    var $form = this.$form;
     _.each(values, function(v) {
-      $el.find('option[value="' + v + '"]').each(function() {
-        this.selected = 'selected';
-      });
+      var match = $el.find('option[value="' + v + '"]');
+      if (match.length) {
+        match.each(function() {
+          this.selected = 'selected';
+        });
+      }
+      // add the value as an option if none exists
+      else {
+        $form.append($('<option />', {checked: true, value: value, text: value}));
+        $form.trigger('liszt:updated');
+      }
     });
   }
 });

--- a/app/views/meta/text.js
+++ b/app/views/meta/text.js
@@ -6,6 +6,7 @@ var templates = require('../../../dist/templates');
 module.exports = Backbone.View.extend({
 
   template: templates.meta.text,
+  type: 'text',
 
   initialize: function(options) {
     this.name = options.data.name;
@@ -33,5 +34,10 @@ module.exports = Backbone.View.extend({
   getValue: function() {
     return this.options.data.type === 'number' ?
       Number(this.$form.val()) : this.$form.val();
+  },
+
+  setValue: function(value) {
+    this.$form.val(value);
   }
+
 });

--- a/app/views/meta/text.js
+++ b/app/views/meta/text.js
@@ -1,0 +1,26 @@
+var $ = require('jquery-browserify');
+var Backbone = require('backbone');
+var _ = require('underscore');
+var templates = require('../../../dist/templates');
+
+module.exports = Backbone.View.extend({
+
+  template: templates.meta.text,
+
+  render: function () {
+    var data = this.options.data;
+
+    var text = {
+      name: data.name,
+      label: data.field.label,
+      help: data.field.help,
+      value: data.field.value,
+      placeholder: data.field.placeholder,
+      type: data.type
+    };
+
+    return _.template(this.template, text, {
+      variable: 'meta'
+    });
+  }
+});

--- a/app/views/meta/text.js
+++ b/app/views/meta/text.js
@@ -7,6 +7,10 @@ module.exports = Backbone.View.extend({
 
   template: templates.meta.text,
 
+  initialize: function(options) {
+    this.name = options.data.name;
+  },
+
   render: function () {
     var data = this.options.data;
 
@@ -19,8 +23,14 @@ module.exports = Backbone.View.extend({
       type: data.type
     };
 
-    return _.template(this.template, text, {
+    this.setElement($(_.template(this.template, text, {
       variable: 'meta'
-    });
+    })));
+    this.$form = this.$el.find('input');
+    return this.$el;
+  },
+
+  getValue: function() {
+    return this.$form.val();
   }
 });

--- a/app/views/meta/text.js
+++ b/app/views/meta/text.js
@@ -31,6 +31,7 @@ module.exports = Backbone.View.extend({
   },
 
   getValue: function() {
-    return this.$form.val();
+    return this.options.data.type === 'number' ?
+      Number(this.$form.val()) : this.$form.val();
   }
 });

--- a/app/views/meta/textarea.js
+++ b/app/views/meta/textarea.js
@@ -79,6 +79,9 @@ module.exports = Backbone.View.extend({
   },
 
   setValue: function(value) {
-    this.codeMirror.setValue(value);
+    // Only set value if not null or undefined.
+    if (value != undefined) {
+      this.codeMirror.setValue(_.escape(value));
+    }
   }
 });

--- a/app/views/meta/textarea.js
+++ b/app/views/meta/textarea.js
@@ -1,0 +1,60 @@
+var $ = require('jquery-browserify');
+var Backbone = require('backbone');
+var _ = require('underscore');
+var templates = require('../../../dist/templates');
+var util = require('../../util');
+
+module.exports = Backbone.View.extend({
+
+  template: templates.meta.textarea,
+
+  initialize: function(options) {
+    this.id = options.data.id;
+  },
+
+  render: function () {
+    var data = this.options.data;
+
+    var textarea = {
+      name: data.name,
+      id: data.id,
+      value: data.field.value,
+      label: data.field.label,
+      help: data.field.help,
+      placeholder: data.field.placeholder,
+      type: 'textarea'
+    };
+
+    return _.template(this.template, textarea, {
+      variable: 'meta'
+    });
+  },
+
+  // Initialize code mirror and save it to this.
+  // Receives onBlur as a callback, which is a hook
+  // to update the parent model.
+  initCodeMirror: function (onBlur) {
+    var id = this.id;
+    var name = this.options.data.name;
+    var textElement = document.getElementById(id);
+    var codeMirror = CodeMirror(function(el) {
+      textElement.parentNode.replaceChild(el, textElement);
+      el.id = id;
+      el.className += ' inner ';
+      el.setAttribute('data-name', name);
+    }, {
+      mode: id,
+      value: textElement.value,
+      lineWrapping: true,
+      theme: 'prose-bright'
+    });
+
+    codeMirror.on('blur', function() {
+      textElement.value = codeMirror.getValue();
+      onBlur({currentTarget: textElement});
+    });
+
+    this.codeMirror = codeMirror;
+    return codeMirror;
+  },
+});

--- a/app/views/meta/textarea.js
+++ b/app/views/meta/textarea.js
@@ -49,7 +49,7 @@ module.exports = Backbone.View.extend({
       theme: 'prose-bright'
     });
 
-    codeMirror.on('blur', function() {
+    this.listenTo(codeMirror, 'blur', function() {
       textElement.value = codeMirror.getValue();
       onBlur({currentTarget: textElement});
     });

--- a/app/views/meta/textarea.js
+++ b/app/views/meta/textarea.js
@@ -1,12 +1,14 @@
 var $ = require('jquery-browserify');
 var Backbone = require('backbone');
 var _ = require('underscore');
+var jsyaml = require('js-yaml');
 var templates = require('../../../dist/templates');
 var util = require('../../util');
 
 module.exports = Backbone.View.extend({
 
   template: templates.meta.textarea,
+  type: 'textarea',
 
   initialize: function(options) {
     this.id = options.data.id;
@@ -52,9 +54,10 @@ module.exports = Backbone.View.extend({
       theme: 'prose-bright'
     });
 
-    this.listenTo(codeMirror, 'blur', function() {
-      textElement.value = codeMirror.getValue();
-      onBlur({currentTarget: textElement});
+    codeMirror.on('blur', function() {
+      onBlur({currentTarget: {
+        value: codeMirror.getValue()
+      }});
     });
 
     // Since other elements have a $form property shorthand
@@ -65,6 +68,17 @@ module.exports = Backbone.View.extend({
   },
 
   getValue: function() {
-    return this.codeMirror.getValue();
+    try {
+      return jsyaml.safeLoad(this.codeMirror.getValue());
+    }
+    catch(err) {
+      console.log('Error parsing yaml front matter for ', this.name);
+      console.log(err);
+      return '';
+    }
+  },
+
+  setValue: function(value) {
+    this.codeMirror.setValue(value);
   }
 });

--- a/app/views/meta/textarea.js
+++ b/app/views/meta/textarea.js
@@ -10,6 +10,7 @@ module.exports = Backbone.View.extend({
 
   initialize: function(options) {
     this.id = options.data.id;
+    this.name = options.data.name;
   },
 
   render: function () {
@@ -25,9 +26,11 @@ module.exports = Backbone.View.extend({
       type: 'textarea'
     };
 
-    return _.template(this.template, textarea, {
+    this.setElement($(_.template(this.template, textarea, {
       variable: 'meta'
-    });
+    })));
+
+    return this.$el;
   },
 
   // Initialize code mirror and save it to this.
@@ -54,7 +57,14 @@ module.exports = Backbone.View.extend({
       onBlur({currentTarget: textElement});
     });
 
+    // Since other elements have a $form property shorthand
+    // for the form element, make this consistent.
     this.codeMirror = codeMirror;
+    this.$form = codeMirror;
     return codeMirror;
   },
+
+  getValue: function() {
+    return this.codeMirror.getValue();
+  }
 });

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -7,6 +7,13 @@ var Backbone = require('backbone');
 var templates = require('../../dist/templates');
 var util = require('.././util');
 
+// Creates form elements that correspond to Jekyll frontmatter.
+//
+// Handles the reading and updating of object/key pairs
+// on the file model.
+//
+// This view is always a child view of views/file.js.
+
 module.exports = Backbone.View.extend({
   template: templates.metadata,
 
@@ -16,6 +23,13 @@ module.exports = Backbone.View.extend({
     'click .finish': 'exit'
   },
 
+  // @options object
+  // @options.model object (file model attached to file view)
+  // @options.view object (file view)
+  // @options.titleAsHeading boolean
+  //
+  // titleAsHeading is true when the filetype is markdown,
+  // and when there exists a meta field called title.
   initialize: function(options) {
     _.bindAll(this);
 
@@ -24,6 +38,8 @@ module.exports = Backbone.View.extend({
     this.view = options.view;
   },
 
+  // Parent file view calls this render func immediately
+  // after initializing this view.
   render: function() {
     this.$el.empty().append(_.template(this.template));
 
@@ -32,157 +48,166 @@ module.exports = Backbone.View.extend({
     var metadata = this.model.get('metadata');
     var lang = metadata && metadata.lang ? metadata.lang : 'en';
 
-    // This renders any fields defined in the metadata entry
-    // of a given prose configuration file.
+    // Using the yml configuration file for metadata,
+    // render form fields.
     _.each(this.model.get('defaults'), (function(data, key) {
       var metadata = this.model.get('metadata') || {};
+
+      // Tests that 1. This is the title metadata,
+      // and 2. We've decided to combine the title form UI as the page header.
+      // If both are true, then don't render this default.
+      // TODO this is a very confusing naming scheme.
+      // If renderTitle is true, then we render, and it is not necessarily a title.
       var renderTitle = true;
 
       if (data && data.name === 'title' && this.titleAsHeading) {
         renderTitle = false;
       }
 
+      // TODO this is way too frustrating to read, and needs re-factoring.
+      // Each UI item should be it's own function.
       if (renderTitle) {
         if (data && data.field) {
           switch (data.field.element) {
             case 'button':
               var button = {
-                name: data.name,
-                label: data.field.label,
-                help: data.field.help,
-                on: data.field.on,
-                off: data.field.off
-              };
+              name: data.name,
+              label: data.field.label,
+              help: data.field.help,
+              on: data.field.on,
+              off: data.field.off
+            };
 
-              form.append(_.template(templates.meta.button, button, {
-                variable: 'meta'
-              }));
-              break;
+            form.append(_.template(templates.meta.button, button, {
+              variable: 'meta'
+            }));
+            break;
             case 'checkbox':
               var checkbox = {
-                name: data.name,
-                label: data.field.label,
-                help: data.field.help,
-                value: data.name,
-                checked: data.field.value
-              };
+              name: data.name,
+              label: data.field.label,
+              help: data.field.help,
+              value: data.name,
+              checked: data.field.value
+            };
 
-              form.append(_.template(templates.meta.checkbox, checkbox, {
-                variable: 'meta'
-              }));
-              break;
+            form.append(_.template(templates.meta.checkbox, checkbox, {
+              variable: 'meta'
+            }));
+            break;
             case 'text':
               var text = {
-                name: data.name,
-                label: data.field.label,
-                help: data.field.help,
-                value: data.field.value,
-                placeholder: data.field.placeholder,
-                type: 'text'
-              };
+              name: data.name,
+              label: data.field.label,
+              help: data.field.help,
+              value: data.field.value,
+              placeholder: data.field.placeholder,
+              type: 'text'
+            };
 
-              form.append(_.template(templates.meta.text, text, {
-                variable: 'meta'
-              }));
-              break;
+            form.append(_.template(templates.meta.text, text, {
+              variable: 'meta'
+            }));
+            break;
             case 'textarea':
               var id = util.stringToUrl(data.name);
-              var textarea = {
-                name: data.name,
-                id: id,
-                value: data.field.value,
-                label: data.field.label,
-                help: data.field.help,
-                placeholder: data.field.placeholder,
-                type: 'textarea'
-              };
+            var textarea = {
+              name: data.name,
+              id: id,
+              value: data.field.value,
+              label: data.field.label,
+              help: data.field.help,
+              placeholder: data.field.placeholder,
+              type: 'textarea'
+            };
 
-              form.append(_.template(templates.meta.textarea, textarea, {
-                variable: 'meta'
-              }));
+            form.append(_.template(templates.meta.textarea, textarea, {
+              variable: 'meta'
+            }));
 
-              var textElement = document.getElementById(id);
+            var textElement = document.getElementById(id);
 
-              var cm = CodeMirror(function(el) {
-                textElement.parentNode.replaceChild(el, textElement);
-                el.id = id;
-                el.className += ' inner ';
-                el.setAttribute('data-name', data.name);
-              }, {
-                mode: id,
-                value: textElement.value,
-                lineWrapping: true,
-                theme: 'prose-bright'
+            var cm = CodeMirror(function(el) {
+              textElement.parentNode.replaceChild(el, textElement);
+              el.id = id;
+              el.className += ' inner ';
+              el.setAttribute('data-name', data.name);
+            }, {
+              mode: id,
+              value: textElement.value,
+              lineWrapping: true,
+              theme: 'prose-bright'
+            });
+            cm.on('blur', (function(){
+              textElement.value = cm.getValue();
+              this.updateModel({
+                currentTarget: textElement
               });
-              cm.on('blur', (function(){
-                textElement.value = cm.getValue();
-                this.updateModel({
-                    currentTarget: textElement
-                });
-              }).bind(this));
-              this[id] = cm;
+            }).bind(this));
+            this[id] = cm;
 
-              break;
+            break;
             case 'number':
               var number = {
-                name: data.name,
-                label: data.field.label,
-                help: data.field.help,
-                value: data.field.value,
-                type: 'number'
-              };
+              name: data.name,
+              label: data.field.label,
+              help: data.field.help,
+              value: data.field.value,
+              type: 'number'
+            };
 
-              form.append(_.template(templates.meta.text, number, {
-                variable: 'meta'
-              }));
-              break;
+            form.append(_.template(templates.meta.text, number, {
+              variable: 'meta'
+            }));
+            break;
             case 'select':
               var select = {
-                name: data.name,
-                label: data.field.label,
-                help: data.field.help,
-                placeholder: data.field.placeholder,
-                options: data.field.options,
-                lang: lang
-              };
+              name: data.name,
+              label: data.field.label,
+              help: data.field.help,
+              placeholder: data.field.placeholder,
+              options: data.field.options,
+              lang: lang
+            };
 
-              form.append(_.template(templates.meta.select, select, {
-                variable: 'meta'
-              }));
-              break;
+            form.append(_.template(templates.meta.select, select, {
+              variable: 'meta'
+            }));
+            break;
             case 'multiselect':
               var multiselect = {
-                name: data.name,
-                label: data.field.label,
-                help: data.field.help,
-                alterable: data.field.alterable,
-                placeholder: data.field.placeholder,
-                options: data.field.options,
-                lang: lang
-              };
+              name: data.name,
+              label: data.field.label,
+              help: data.field.help,
+              alterable: data.field.alterable,
+              placeholder: data.field.placeholder,
+              options: data.field.options,
+              lang: lang
+            };
 
-              form.append(_.template(templates.meta.multiselect, multiselect, {
-                variable: 'meta'
-              }));
+            form.append(_.template(templates.meta.multiselect, multiselect, {
+              variable: 'meta'
+            }));
 
-              break;
+            break;
             case 'hidden':
               var tmpl = {};
-              var value = metadata[data.name];
+            var value = metadata[data.name];
 
-              if (_.isArray(value)) {
-                // Any defaults not currently in metadata?
-                var diff = _.difference(data.field.value, value);
-                tmpl[data.name] = diff.length ?
-                  _.union(data.field.value, value) : value;
-              } else {
-                tmpl[data.name] = data.field.value;
-              }
+            if (_.isArray(value)) {
+              // Any defaults not currently in metadata?
+              var diff = _.difference(data.field.value, value);
+              tmpl[data.name] = diff.length ?
+                _.union(data.field.value, value) : value;
+            } else {
+              tmpl[data.name] = data.field.value;
+            }
 
-              this.model.set('metadata', _.extend(tmpl, this.model.get('metadata') || {}));
-              break;
+            this.model.set('metadata', _.extend(tmpl, this.model.get('metadata') || {}));
+            break;
           }
         } else {
+          // This just defaults to a text element if there's no field type.
           var txt = {
             name: key,
             label: key,
@@ -197,12 +222,25 @@ module.exports = Backbone.View.extend({
       }
     }).bind(this));
 
+    // Attach a change event listener
     this.$el.find('.chzn-select').chosen().change(this.updateModel);
+    // Renders the raw metadata textarea form
     this.renderRaw();
 
     return this;
   },
 
+  // Convenience method to save changes to file model
+  // on some sort of event callback.
+  //
+  // fileView.makeDirty() calls set on the file model,
+  // known locally here as this.model, using this.getValue(),
+  // which is below.
+  //
+  // TODO calling the parent view so it can set it's model based
+  // on a method in the child (this) view is too heavy-handed coupling.
+  // Since this view has access to the proper model, it should
+  // do the updating here.
   updateModel: function(e) {
     var target = e.currentTarget;
     var key = target.name;
@@ -215,16 +253,24 @@ module.exports = Backbone.View.extend({
     this.view.makeDirty();
   },
 
+  // TODO This.view is vague and doesn't get across that we're
+  // communicating with the parent file view.
+  //
+  // It also doesn't get across that we're performing a save operation.
   rawKeyMap: function() {
     return {
       'Ctrl-S': this.view.updateFile
     };
   },
 
+  // Responsible for rendering the raw metadata element
+  // and listening for changes.
   renderRaw: function() {
     var yaml = this.model.get('lang') === 'yaml';
     var $el;
 
+    // TODO Not sure why this is necessary, but it seems
+    // an extra element is rendered on yaml files.
     if (yaml) {
       $el = this.view.$el.find('#code');
       $el.empty();
@@ -234,6 +280,7 @@ module.exports = Backbone.View.extend({
 
     var el = (yaml ? $el : this.$el.find('#raw'))[0];
 
+    // TODO rename this.raw to rawEditor or something more descriptive.
     this.raw = CodeMirror(el, {
       mode: 'yaml',
       value: '',
@@ -243,6 +290,8 @@ module.exports = Backbone.View.extend({
       theme: 'prose-bright'
     });
 
+    // TODO there should be a listenToCodeMirror function
+    // since this is probably repeated later on down.
     this.listenTo(this.raw, 'blur', (function(cm) {
       var value = cm.getValue();
       var raw;
@@ -269,6 +318,7 @@ module.exports = Backbone.View.extend({
     var view = this;
     var metadata = this.model.get('metadata') || {};
 
+    // TODO this would always seem to default metadata.published to true.
     if (this.view.toolbar &&
        this.view.toolbar.publishState() ||
        (metadata && metadata.published)) {
@@ -284,6 +334,7 @@ module.exports = Backbone.View.extend({
         this.model.get('metadata').title[0];
     }
 
+    // Extracts values from each native form element.
     _.each(this.$el.find('[name]'), function(item) {
       var $item = $(item);
       var value = $item.val();
@@ -330,6 +381,9 @@ module.exports = Backbone.View.extend({
     });
 
     // Load any data coming from a yaml-block of content.
+    // aka this is what gets stuff from the textareas.
+    // TODO getValue is probably throwing an error here.
+    // TODO this is also causing name collisions.
     this.$el.find('.yaml-block').each(function() {
       var editor = $(this).find('.CodeMirror').attr('id');
       var name = $('#' + editor).data('name');
@@ -357,14 +411,20 @@ module.exports = Backbone.View.extend({
     return metadata;
   },
 
+  // @data object metadata key/value pairs
+  // Syncs the visual UI with what's currently saved on the model.
   setValue: function(data) {
     var form = this.$el.find('.form');
     var missing = {};
     var raw;
 
+    // For each metadata key/value pair, check to see if it exists,
+    // and if it does, update it's value.
+    // If no matches are found, attempt to create a new field.
     _.each(data, (function(value, key) {
       var matched = false;
       var input = this.$el.find('[name="' + key + '"]');
+      // TODO length is not something we need to cache.
       var length = input.length;
       var options;
 
@@ -374,33 +434,34 @@ module.exports = Backbone.View.extend({
         for (var i = 0; i < length; i++) {
 
           // if value is an array
+          // TODO check if value is ever an array.
           if (_.isArray(value)) {
 
             // iterate over values in array
             for (var j = 0; j < value.length; j++) {
               switch (input[i].type) {
                 case 'select-multiple':
-                case 'select-one':
+                  case 'select-one':
                   options = $(input[i]).find('option[value="' + value[j] + '"]');
-                  if (options.length) {
-                    for (var k = 0; k < options.length; k++) {
-                      options[k].selected = 'selected';
-                    }
-
-                    matched = true;
+                if (options.length) {
+                  for (var k = 0; k < options.length; k++) {
+                    options[k].selected = 'selected';
                   }
-                  break;
-                case 'text':
-                case 'textarea':
-                  input[i].value = value;
+
                   matched = true;
-                  break;
+                }
+                break;
+                case 'text':
+                  case 'textarea':
+                  input[i].value = value;
+                matched = true;
+                break;
                 case 'checkbox':
                   if (input[i].value === value) {
-                    input[i].checked = 'checked';
-                    matched = true;
-                  }
-                  break;
+                  input[i].checked = 'checked';
+                  matched = true;
+                }
+                break;
               }
             }
 
@@ -408,30 +469,30 @@ module.exports = Backbone.View.extend({
 
             switch (input[i].type) {
               case 'select-multiple':
-              case 'select-one':
+                case 'select-one':
                 options = $(input[i]).find('option[value="' + value + '"]');
-                if (options.length) {
-                  for (var m = 0; m < options.length; m++) {
-                    options[m].selected = 'selected';
-                  }
-
-                  matched = true;
+              if (options.length) {
+                for (var m = 0; m < options.length; m++) {
+                  options[m].selected = 'selected';
                 }
-                break;
-              case 'text':
-              case 'textarea':
-                input[i].value = value;
+
                 matched = true;
-                break;
+              }
+              break;
+              case 'text':
+                case 'textarea':
+                input[i].value = value;
+              matched = true;
+              break;
               case 'checkbox':
                 input[i].checked = value ? 'checked' : false;
-                matched = true;
-                break;
+              matched = true;
+              break;
               case 'button':
                 input[i].value = value ? true : false;
-                input[i].innerHTML = value ? input[i].getAttribute('data-on') : input[i].getAttribute('data-off');
-                matched = true;
-                break;
+              input[i].innerHTML = value ? input[i].getAttribute('data-on') : input[i].getAttribute('data-off');
+              matched = true;
+              break;
             }
 
           }
@@ -451,6 +512,7 @@ module.exports = Backbone.View.extend({
         var defaults = _.find(this.model.get('defaults'), function(data) { return data && (data.name === key); });
         var diff = defaults && _.isArray(value) ? _.difference(value, defaults.field.value) : value;
 
+        // TODO Kind of a silly way to determine whether this is the raw editor or not.
         if (key !== 'published' && key !== 'title' && !defaults) {
           raw = {};
           raw[key] = value;
@@ -462,50 +524,52 @@ module.exports = Backbone.View.extend({
       }
     }).bind(this));
 
+    // TODO is this necessary? Do we ever get a missing value?
+    // What case does this cover?
     _.each(missing, (function(value, key) {
       if (value === null) return;
 
       switch (typeof value) {
         case 'boolean':
           var bool = {
-            name: key,
-            label: value,
-            value: value,
-            checked: value ? 'checked' : false
-          };
+          name: key,
+          label: value,
+          value: value,
+          checked: value ? 'checked' : false
+        };
 
-          form.append(_.template(templates.meta.checkbox, bool, {
-            variable: 'meta'
-          }));
-          break;
+        form.append(_.template(templates.meta.checkbox, bool, {
+          variable: 'meta'
+        }));
+        break;
         case 'string':
           var string = {
-            name: key,
-            label: value,
-            value: value,
-            type: 'text'
-          };
+          name: key,
+          label: value,
+          value: value,
+          type: 'text'
+        };
 
-          form.append(_.template(templates.meta.text, string, {
-            variable: 'meta'
-          }));
-          break;
+        form.append(_.template(templates.meta.text, string, {
+          variable: 'meta'
+        }));
+        break;
         case 'object':
           var obj = {
-            name: key,
-            label: key,
-            placeholder: key,
-            options: value,
-            lang: data.lang || 'en'
-          };
+          name: key,
+          label: key,
+          placeholder: key,
+          options: value,
+          lang: data.lang || 'en'
+        };
 
-          form.append(_.template(templates.meta.multiselect, obj, {
-            variable: 'meta'
-          }));
-          break;
+        form.append(_.template(templates.meta.multiselect, obj, {
+          variable: 'meta'
+        }));
+        break;
         default:
           console.log('ERROR could not create metadata field for ' + typeof value, key + ': ' + value);
-          break;
+        break;
       }
 
       this.$el.find('.chzn-select').chosen().change(this.updateModel);
@@ -525,6 +589,7 @@ module.exports = Backbone.View.extend({
   setRaw: function(data) {
     try {
       this.raw.setValue(jsyaml.safeDump(data));
+      // TODO this isn't actually calling refresh.
       this.refresh;
     } catch (err) {
       throw err;
@@ -535,6 +600,7 @@ module.exports = Backbone.View.extend({
     var view = this;
     this.$el.find('.yaml-block').each(function() {
       var editor = $(this).find('.CodeMirror').attr('id');
+      // TODO instance of possible name collision.
       if (view[editor]) view[editor].refresh();
     });
 

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -29,6 +29,7 @@ module.exports = Backbone.View.extend({
 
   events: {
     'change .metafield': 'updateModel',
+    'click button.metafield': 'updateModel',
     'click .create-select': 'createSelect',
     'click .finish': 'exit'
   },
@@ -177,6 +178,11 @@ module.exports = Backbone.View.extend({
     // to defaults, sync the form elements with the current metadata.
     this.setValue(this.model.get('metadata'));
 
+    // Now that we've synced the values from metadata, do a save to model.
+    // Important because some elements, such as buttons, rely on a default
+    // and don't save to the metadata model until we explicitly call this.
+    this.model.set('metadata', this.getValue());
+
     return this;
   },
 
@@ -307,6 +313,11 @@ module.exports = Backbone.View.extend({
       var renderedViews = _.filter(subviews, function(view) {
         return view.name === key;
       });
+
+      // If there are n rendered views corresponding to n
+      // metadata values of the same name, assign values based on order.
+      // This works because metadata yaml is parsed in order, and
+      // subviews is an ordered array.
       if (renderedViews.length && _.isArray(value)
           && value.length === renderedViews.length) {
         _.each(renderedViews, function(view, i) {

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -194,6 +194,11 @@ module.exports = Backbone.View.extend({
   //
   // TODO calling updateModel on a checkbox change means the metadata
   // value is set to the name (or value) of the element, not true or false.
+  //
+  // TODO in general this function sucks. It sets the metadata naively using
+  // form.value, which can easily throw off tests for checkboxes and numbers.
+  // It also calls view.makeDirty(), which sets the metadata anyway.
+  // Investigate whether we can avoid calling model.set here.
   updateModel: function(e) {
     var target = e.currentTarget;
     var delta = {};
@@ -258,6 +263,8 @@ module.exports = Backbone.View.extend({
     // First get values from all subviews.
     _.each(this.subviews, function(view) {
       var value = view.getValue();
+
+
     });
 
 

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -371,5 +371,11 @@ module.exports = Backbone.View.extend({
     }
 
     return false;
+  },
+
+  remove: function() {
+    _.invoke(this.subviews, 'remove');
+    this.subviews = [];
+    Backbone.View.prototype.remove.apply(this, arguments);
   }
 });

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -284,6 +284,9 @@ module.exports = Backbone.View.extend({
       }
     }
 
+    // TODO Currently, it's not possible to delete metadata.
+    // There should be some logic here that looks to see if there's any metadata
+    // that isn't an element, isn't hidden, and isn't in the raw editor.
     return metadata;
   },
 

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -180,30 +180,9 @@ module.exports = Backbone.View.extend({
     return this;
   },
 
-  // Convenience method to save changes to file model
-  // on some sort of event callback.
-  //
-  // fileView.makeDirty() calls set on the file model,
-  // known locally here as this.model, using this.getValue(),
-  // which is below.
-  //
-  // TODO calling the parent view so it can set it's model based
-  // on a method in the child (this) view is too heavy-handed coupling.
-  // Since this view has access to the proper model, it should
-  // do the updating here.
-  //
-  // TODO calling updateModel on a checkbox change means the metadata
-  // value is set to the name (or value) of the element, not true or false.
-  //
-  // TODO in general this function sucks. It sets the metadata naively using
-  // form.value, which can easily throw off tests for checkboxes and numbers.
-  // It also calls view.makeDirty(), which sets the metadata anyway.
-  // Investigate whether we can avoid calling model.set here.
-  updateModel: function(e) {
-    var target = e.currentTarget;
-    var delta = {};
-    delta[target.name] = target.value;
-    this.model.set('metadata', _.extend(this.model.get('metadata'), delta));
+  // Record metadata, signal to file that a save is possible.
+  updateModel: function() {
+    this.model.set('metadata', this.getValue());
     this.view.makeDirty();
   },
 

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -70,108 +70,99 @@ module.exports = Backbone.View.extend({
       // Tests that 1. This is the title metadata,
       // and 2. We've decided to combine the title form UI as the page header.
       // If both are true, then don't render this default.
-      // TODO this is a very confusing naming scheme.
-      // If renderTitle is true, then we render, and it is not necessarily a title.
-      var renderTitle = true;
-
       if (data && data.name === 'title' && this.titleAsHeading) {
-        renderTitle = false;
+        return;
       }
 
-      // TODO this is way too frustrating to read, and needs re-factoring.
-      // Each UI item should be it's own function.
-      if (renderTitle) {
+      var view = null;
 
-        var view = null;
-
-        // If there's no data field, default to text field.
-        if (!data || (data && !data.field)) {
-          var field = {
-            label: key,
-            value: data,
-          }
-          view = new forms.TextForm({data: {
-            name: key,
-            type: 'text',
-            field: field
-          }});
+      // If there's no data field, default to text field.
+      if (!data || (data && !data.field)) {
+        var field = {
+          label: key,
+          value: data,
         }
+        view = new forms.TextForm({data: {
+          name: key,
+          type: 'text',
+          field: field
+        }});
+      }
 
-        // Use the data field to determine the kind of meta form to draw.
-        else {
-          switch (data.field.element) {
-            case 'button':
-              view = new forms.Button({data: data});
-            break;
-            case 'checkbox':
-              view = new forms.Checkbox({data: data});
-            break;
-            case 'text':
-              view = new forms.TextForm({
-                data: _.extend({}, data, {type: 'text'})
-              });
-            break;
-            case 'textarea':
-              view = new forms.TextArea({
-                data: _.extend({}, data, {id: util.stringToUrl(data.name)})
-              });
-            break;
-            case 'number':
-              view = new forms.TextForm({
-                data: _.extend({}, data, {type: 'number'})
-              });
-            break;
-            case 'select':
-              view = new forms.Select({
-                data: _.extend({}, data, {lang: lang})
-              });
-            break;
-            case 'multiselect':
-              view = new forms.Multiselect({
-                data: _.extend({}, data, {lang: lang})
-              });
-            break;
+      // Use the data field to determine the kind of meta form to draw.
+      else {
+        switch (data.field.element) {
+          case 'button':
+            view = new forms.Button({data: data});
+          break;
+          case 'checkbox':
+            view = new forms.Checkbox({data: data});
+          break;
+          case 'text':
+            view = new forms.TextForm({
+              data: _.extend({}, data, {type: 'text'})
+            });
+          break;
+          case 'textarea':
+            view = new forms.TextArea({
+              data: _.extend({}, data, {id: util.stringToUrl(data.name)})
+            });
+          break;
+          case 'number':
+            view = new forms.TextForm({
+              data: _.extend({}, data, {type: 'number'})
+            });
+          break;
+          case 'select':
+            view = new forms.Select({
+              data: _.extend({}, data, {lang: lang})
+            });
+          break;
+          case 'multiselect':
+            view = new forms.Multiselect({
+              data: _.extend({}, data, {lang: lang})
+            });
+          break;
 
-            // On hidden values, we obviously don't have to render anything.
-            // Just make sure this default is saved on the metadata object.
-            case 'hidden':
-              var preExisting = metadata[data.name];
-              var newDefault = data.field.value;
-              var newMeta = {};
+          // On hidden values, we obviously don't have to render anything.
+          // Just make sure this default is saved on the metadata object.
+          case 'hidden':
+            var preExisting = metadata[data.name];
+            var newDefault = data.field.value;
+            var newMeta = {};
 
-              // If the pre-existing metadata is an array,
-              // make sure we don't just override it, but we find the difference.
-              if (_.isArray(preExisting)) {
-                newMeta[data.name] = _.difference(newDefault, preExisting).length ?
-                  _.union(newDefault, preExisting) : preExisting;
-              }
-              // If pre-existing is a single property or undefined,
-              // use _.extend to default to pre-existing if it exists, or
-              // newDefault if there is no pre-existing.
-              else {
-                newMeta[data.name] = newDefault;
-              }
-              this.model.set('metadata', _.extend(newMeta, this.model.get('metadata') || {}));
-            break;
-          }
+            // If the pre-existing metadata is an array,
+            // make sure we don't just override it, but we find the difference.
+            if (_.isArray(preExisting)) {
+              newMeta[data.name] = _.difference(newDefault, preExisting).length ?
+                _.union(newDefault, preExisting) : preExisting;
+            }
+            // If pre-existing is a single property or undefined,
+            // use _.extend to default to pre-existing if it exists, or
+            // newDefault if there is no pre-existing.
+            else {
+              newMeta[data.name] = newDefault;
+            }
+            this.model.set('metadata', _.extend(newMeta, this.model.get('metadata') || {}));
+          break;
         }
+      }
 
-        if (view !== null) {
-          $form.append(view.render());
-          this.subviews.push(view);
+      if (view !== null) {
+        $form.append(view.render());
+        this.subviews.push(view);
 
-          // If the view is a text area, we'll need to init codemirror.
-          if (data && data.field && data.field.element === 'textarea') {
-            var id = util.stringToUrl(data.name);
+        // If the view is a text area, we'll need to init codemirror.
+        if (data && data.field && data.field.element === 'textarea') {
+          var id = util.stringToUrl(data.name);
 
-            // TODO passing in a bound callback is not the best
-            // as it increases the debugging surface area.
-            // Find some way to get around this.
-            var codeMirror = view.initCodeMirror(this.updateModel.bind(this));
+          // TODO passing in a bound callback is not the best
+          // as it increases the debugging surface area.
+          // Find some way to get around this.
+          var codeMirror = view.initCodeMirror(this.updateModel.bind(this));
 
-            // TODO fix collision here
-            this[id] = codeMirror;
-          }
+          // TODO fix collision here
+          this[id] = codeMirror;
         }
       }
     }).bind(this));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,7 @@ gulp.task('build-tests', ['templates', 'oauth', 'vendor'], function() {
     .bundle()
     .pipe(source('polyfill.js'))
     .pipe(gulp.dest('./test/lib/'));
-    
+
   // Browserify index.js
   // Pass `debug` option to enable source maps.
   return browserify({debug: true})
@@ -179,7 +179,7 @@ gulp.task('uglify', ['build-app'], function() {
 //
 gulp.task('watch', ['build-app', 'build-tests'], function() {
   // Watch any `.js` file under `app` folder.
-  gulp.watch(paths.app, ['build-app']);
+  gulp.watch(paths.app, ['build-app', 'build-tests']);
   gulp.watch(paths.test, ['build-tests']);
   gulp.watch(paths.templates, ['build-app']);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,7 +144,7 @@ gulp.task('build-app', ['templates', 'oauth', 'vendor'], function() {
 
 
   // Browserify app scripts.
-  return browserify({debug: true})
+  return browserify()
     .add('./app/boot.js')
     .bundle()
     .pipe(source('app.js'))

--- a/templates/meta/button.html
+++ b/templates/meta/button.html
@@ -2,8 +2,6 @@
   <label for='<%= meta.name %>'><%= meta.label %></label>
   <% if (meta.help) { %><small class='deemphasize'><%= meta.help %></small><% } %>
   <fieldset>
-    <button class='metafield round <%= meta.name %>' type='button' name='<%= meta.name %>' value='<%= meta.value %>' data-on='<%= meta.on %>' data-off='<%= meta.off %>'>
-      <% print(value ? meta.on : meta.off); %>
-    </button>
+    <button class='metafield round <%= meta.name %>' type='button' name='<%= meta.name %>' value='<%= meta.value %>' data-on='<%= meta.on %>' data-off='<%= meta.off %>'><%= meta.on %></button>
   </fieldset>
 </div>

--- a/test/index.js
+++ b/test/index.js
@@ -15,4 +15,5 @@ require('./spec/models/repo');
 require('./spec/models/file');
 require('./spec/views/file');
 require('./spec/views/metadata');
+require('./spec/views/meta-forms');
 require('./spec/collections/files');

--- a/test/spec/views/meta-forms.js
+++ b/test/spec/views/meta-forms.js
@@ -35,6 +35,7 @@ describe('Metadata form elements', function() {
 
   describe('Reading values', function() {
     it('reads values from a text element', function() {
+      data.type = 'text';
       var text = new TextForm({data: data});
       $('#meta').append(text.render());
       $('[name="foo"]').val('bar');
@@ -48,6 +49,14 @@ describe('Metadata form elements', function() {
       $('#meta').append(textarea.render());
       textarea.initCodeMirror(function() {});
       expect(textarea.getValue()).to.equal('bar');
+    });
+
+    it('reads values from a number element', function() {
+      data.type = 'number';
+      var number = new TextForm({data: data});
+      $('#meta').append(number.render());
+      $('[name="foo"]').val(5);
+      expect(number.getValue()).to.equal(5);
     });
 
     it('reads values from a checkbox element', function() {

--- a/test/spec/views/meta-forms.js
+++ b/test/spec/views/meta-forms.js
@@ -66,14 +66,23 @@ describe('Metadata form elements', function() {
       expect(checkbox.getValue()).to.equal(false);
     });
 
-    it('reads values from a button element (TODO)', function() {
-      // This test is broken because the button element is broken.
-      // https://github.com/prose/prose/issues/859
-      data.field.on = 'on';
-      data.field.off = 'off';
+    it('reads values from a button element, and sets values', function() {
+      data.field.on = 'foo';
+      data.field.off = 'bar';
       var button = new Button({data: data});
       $('#meta').append(button.render());
-      expect(button.getValue()).to.equal('on');
+      expect(button.getValue()).to.equal(true);
+      button.setValue('bar');
+      expect(button.getValue()).to.equal(false);
+    });
+
+    it('sets values on button element to false if outside of bounds', function() {
+      data.field.on = 'foo';
+      data.field.off = 'bar';
+      var button = new Button({data: data});
+      $('#meta').append(button.render());
+      button.setValue('baz');
+      expect(button.getValue()).to.equal(false);
     });
 
     it('reads values from a select element', function() {

--- a/test/spec/views/meta-forms.js
+++ b/test/spec/views/meta-forms.js
@@ -1,0 +1,102 @@
+var $ = require('jquery-browserify');
+var _ = require('underscore');
+var chosen = require('chosen-jquery-browserify');
+
+var Checkbox = require('../../../app/views/meta/checkbox');
+var TextForm = require('../../../app/views/meta/text');
+var TextArea = require('../../../app/views/meta/textarea');
+var Button = require('../../../app/views/meta/button');
+var Select = require('../../../app/views/meta/select');
+var Multiselect = require('../../../app/views/meta/multiselect');
+
+'use strict';
+
+var sampleData = {
+  name: 'foo',
+  field: {
+    label: 'foo label',
+    help: 'foo help',
+  }
+}
+
+describe('Metadata form elements', function() {
+
+  // Convenient way to give us a new data object
+  // to work with for each test.
+  var data;
+  beforeEach(function() {
+    data = _.extend({}, sampleData);
+    $('<div />', {id: 'meta'}).appendTo($('body'));
+  });
+
+  afterEach(function() {
+    $('#meta').remove();
+  });
+
+  describe('Reading values', function() {
+    it('reads values from a text element', function() {
+      var text = new TextForm({data: data});
+      $('#meta').append(text.render());
+      $('[name="foo"]').val('bar');
+      expect(text.getValue()).to.equal('bar');
+    });
+
+    it('reads values from a text area element', function() {
+      data.field.value = 'bar';
+      data.id = 'baz';
+      var textarea = new TextArea({data: data});
+      $('#meta').append(textarea.render());
+      textarea.initCodeMirror(function() {});
+      expect(textarea.getValue()).to.equal('bar');
+    });
+
+    it('reads values from a checkbox element', function() {
+      data.field.value = false;
+      var checkbox = new Checkbox({data: data});
+      $('#meta').append(checkbox.render());
+      expect(checkbox.getValue()).to.equal(false);
+    });
+
+    it('reads values from a button element (TODO)', function() {
+      // This test is broken because the button element is broken.
+      // https://github.com/prose/prose/issues/859
+      data.field.on = 'on';
+      data.field.off = 'off';
+      var button = new Button({data: data});
+      $('#meta').append(button.render());
+      expect(button.getValue()).to.equal('on');
+    });
+
+    it('reads values from a select element', function() {
+      data.field.options = [
+        {name: 'Dan', value: 'dan'},
+        {name: 'Jon', value: 'jon'},
+        {name: 'Sre', value: 'sre'}
+      ];
+      var select = new Select({data: data});
+      $('#meta').append(select.render());
+      $('.chzn-select').chosen();
+
+      var $select = select.$form;
+      $select[0].selectedIndex=2;
+      $select.trigger('liszt:updated');
+      expect(select.getValue()).to.equal('sre');
+    });
+
+    it('reads values from a multiselect element', function() {
+      data.field.options = [
+        {name: 'Dan', value: 'dan'},
+        {name: 'Jon', value: 'jon'},
+        {name: 'Sre', value: 'sre'}
+      ];
+      var multiselect = new Multiselect({data: data});
+      $('#meta').append(multiselect.render());
+      $('.chzn-select').chosen();
+
+      var $select = multiselect.$form;
+      $select[0].selectedIndex=1;
+      $select.trigger('liszt:updated');
+      expect(multiselect.getValue()[0]).to.equal('jon');
+    });
+  });
+});

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -75,7 +75,7 @@ describe('Metadata editor view', function() {
     // Metadata object saves references to code-mirror'd textarea elements
     // on itself, or 'this', during render function.
     // This has the potential to overwrite native methods.
-    it('textarea names do not collide with view methods', function() {
+    it('textarea names do not collide with view methods (TODO)', function() {
       var model = mockFile();
       model.set('defaults', [{
         name: 'view',
@@ -109,7 +109,7 @@ describe('Metadata editor view', function() {
       expect(model.get('metadata').foo).to.equal(newValue);
     });
 
-    it('saves changes to model on textarea element change', function() {
+    it('saves changes to model on textarea element change (TODO)', function() {
       var model = mockFile();
       model.set('defaults', [{
         name: 'foo',

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -42,6 +42,92 @@ describe('Metadata editor view', function() {
       expect( $('#meta').find('.form-item').length ).to.equal(1);
     });
 
+    it('creates a text input element with proper default value and label', function() {
+      var model = mockFile();
+      model.set('defaults', [{
+        name: 'text',
+        field: {
+          element: 'text',
+          value: 'hello world',
+          label: 'text label'
+        }
+      }]);
+      metadataEditor.model = model;
+      metadataEditor.render();
+      expect( $('#meta').find('input[type="text"]').length ).to.equal(1);
+      expect( $('#meta').find('input[type="text"]').val() ).to.equal('hello world');
+      expect( $('#meta').find('label[for="text"]').text() ).to.equal('text label');
+    });
+
+    it('creates a textarea element with proper default value and label', function() {
+      var model = mockFile();
+      model.set('defaults', [{
+        name: 'foo',
+        field: {
+          element: 'textarea',
+          label: 'bar',
+          value: '123'
+        }
+      }]);
+      metadataEditor.model = model;
+      metadataEditor.render();
+      expect( $('#meta').find('label[for="foo"]').text() ).to.equal('bar');
+      expect( metadataEditor.foo.getValue() ).to.equal('123');
+    });
+
+    it('creates a multiselect element with proper label and correct options', function() {
+      var model = mockFile();
+      model.set('defaults', [{
+        name: 'multiselect',
+        field: {
+          element: 'multiselect',
+          label: 'multiselect label',
+          options: [
+            {name: 'Dan', value: 'dan'},
+            {name: 'Jon', value: 'jon'}
+          ]
+        }
+      }]);
+      metadataEditor.model = model;
+      metadataEditor.render();
+      expect( $('#meta').find('label[for="multiselect"]').text() ).to.equal('multiselect label');
+      expect( $('#meta').find('ul.chzn-results').find('li').length ).to.equal(2);
+    });
+
+    it('creates a checkbox element with proper default value and label', function() {
+      var model = mockFile();
+      model.set('defaults', [{
+        name: 'checkbox',
+        field: {
+          element: 'checkbox',
+          label: 'checkbox label',
+          vale: false
+        }
+      }]);
+      metadataEditor.model = model;
+      metadataEditor.render();
+      expect( $('#meta').find('input[type="checkbox"]').length ).to.equal(1);
+      expect( $('#meta').find('input[type="checkbox"]:checked').length ).to.equal(0);
+      expect( $('#meta').find('label[for="checkbox"]').text() ).to.equal('checkbox label');
+    });
+
+    it('creates a button element (TODO)', function() {
+      // TODO this models broken behavior.
+      // https://github.com/prose/prose/issues/859
+      var model = mockFile();
+      model.set('defaults', [{
+        name: 'button',
+        field: {
+          element: 'button',
+          on: 'on',
+          off: 'off'
+        }
+      }]);
+      metadataEditor.model = model;
+      metadataEditor.render();
+      expect( $('#meta').find('input[type="button"]').length ).to.equal(1);
+    });
+
     it('does not append hidden meta elements', function() {
       var model = mockFile();
       model.set('defaults', [{
@@ -54,22 +140,6 @@ describe('Metadata editor view', function() {
       metadataEditor.model = model;
       metadataEditor.render();
       expect( $('#meta').find('.form-item').length ).to.equal(1);
-    });
-
-    it('autofills default metadata on textarea elements', function() {
-      var value = '123';
-      var model = mockFile();
-      model.set('defaults', [{
-        name: 'foo',
-        field: {
-          element: 'textarea',
-          label: 'bar',
-          value: value,
-        }
-      }]);
-      metadataEditor.model = model;
-      metadataEditor.render();
-      expect( metadataEditor.foo.getValue() ).to.equal(value);
     });
 
     // Metadata object saves references to code-mirror'd textarea elements

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -12,14 +12,16 @@ describe('Metadata editor view', function() {
 
   var metadataEditor;
 
+  var model;
   beforeEach(function() {
-    var $el = $('<div />', {
+    $('<div />', {
       id: 'meta',
       html: _.template(templates.metadata)
     }).appendTo($('body'));
 
+    model = mockFile();
     metadataEditor = new MetadataView({
-      model: mockFile(),
+      model: model,
       titleAsHeading: '',
       view: mockFileView(),
       el: $('#meta')
@@ -43,7 +45,6 @@ describe('Metadata editor view', function() {
     });
 
     it('creates a text input element with proper default value, label and data-type', function() {
-      var model = mockFile();
       model.set('defaults', [{
         name: 'text',
         field: {
@@ -52,7 +53,6 @@ describe('Metadata editor view', function() {
           label: 'text label'
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
       var $meta = $('#meta').find('input[type="text"]');
       expect($meta.length).to.equal(1);
@@ -62,7 +62,6 @@ describe('Metadata editor view', function() {
     });
 
     it('creates a textarea element with proper default value and label', function() {
-      var model = mockFile();
       model.set('defaults', [{
         name: 'foo',
         field: {
@@ -71,14 +70,12 @@ describe('Metadata editor view', function() {
           value: '123'
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
       expect($('#meta').find('label[for="foo"]').text()).to.equal('bar');
       expect(metadataEditor.foo.getValue()).to.equal('123');
     });
 
     it('creates a select element with proper label and correct options', function() {
-      var model = mockFile();
       model.set('defaults', [{
         name: 'select',
         field: {
@@ -91,14 +88,12 @@ describe('Metadata editor view', function() {
           ]
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
       expect($('#meta').find('label[for="select"]').text()).to.equal('select label');
       expect($('#meta').find('ul.chzn-results').find('li').length).to.equal(3);
     });
 
     it('creates a multiselect element with proper label and correct options', function() {
-      var model = mockFile();
       model.set('defaults', [{
         name: 'multiselect',
         field: {
@@ -110,14 +105,12 @@ describe('Metadata editor view', function() {
           ]
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
       expect($('#meta').find('label[for="multiselect"]').text()).to.equal('multiselect label');
       expect($('#meta').find('ul.chzn-results').find('li').length).to.equal(2);
     });
 
     it('creates a checkbox element with proper default value and label', function() {
-      var model = mockFile();
       model.set('defaults', [{
         name: 'checkbox',
         field: {
@@ -126,7 +119,6 @@ describe('Metadata editor view', function() {
           value: false
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
       expect($('#meta').find('input[type="checkbox"]').length).to.equal(1);
       expect($('#meta').find('input[type="checkbox"]:checked').length).to.equal(0);
@@ -134,7 +126,6 @@ describe('Metadata editor view', function() {
     });
 
     it('creates a number element with proper default value, label, and data-type', function() {
-      var model = mockFile();
       model.set('defaults', [{
         name: 'number',
         field: {
@@ -143,7 +134,6 @@ describe('Metadata editor view', function() {
           value: 4
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
       var $meta = $('#meta').find('input[type="text"]');
       expect($meta.length).to.equal(1);
@@ -155,7 +145,6 @@ describe('Metadata editor view', function() {
     it('creates a button element (TODO)', function() {
       // TODO this models broken behavior.
       // https://github.com/prose/prose/issues/859
-      var model = mockFile();
       model.set('defaults', [{
         name: 'button',
         field: {
@@ -164,23 +153,19 @@ describe('Metadata editor view', function() {
           off: 'off'
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
       expect($('#meta').find('input[type="button"]').length).to.equal(1);
     });
 
     it('creates a text element if no field object exists', function() {
-      var model = mockFile();
       model.set('defaults', [{
         name: 'shouldBeText'
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
       expect($('#meta').find('input[type="text"]').length).to.equal(1);
     });
 
     it('does not append hidden meta elements', function() {
-      var model = mockFile();
       model.set('defaults', [{
         name: 'layout',
         field: {
@@ -188,13 +173,11 @@ describe('Metadata editor view', function() {
           value: 'fixed'
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
       expect($('#meta').find('.form-item').length).to.equal(1);
     });
 
     it('saves defaults that are hidden to metadata', function() {
-      var model = mockFile();
       model.set('defaults', [{
         name: 'layout',
         field: {
@@ -202,7 +185,6 @@ describe('Metadata editor view', function() {
           value: 'fixed'
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
       expect(metadataEditor.model.get('metadata').layout).to.equal('fixed');
     });
@@ -211,23 +193,23 @@ describe('Metadata editor view', function() {
     // on itself, or 'this', during render function.
     // This has the potential to overwrite native methods.
     it('textarea names do not collide with view methods (TODO)', function() {
-      var model = mockFile();
       model.set('defaults', [{
         name: 'view',
         field: {
           element: 'textarea',
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
       expect( metadataEditor.view).to.deep.equal(view);
     });
   });
 
-  describe('saving changes', function() {
 
-    it('saves changes to model on text element change', function() {
-      var model = mockFile();
+  describe('getting values from form elements', function() {
+    // Although there are separate tests for getting values from each meta element individually,
+    // this one is more about the ability of this one to save values to a metadata object.
+
+    it('saves changes to model on change to a text input', function() {
       model.set('defaults', [{
         name: 'foo',
         field: {
@@ -235,7 +217,6 @@ describe('Metadata editor view', function() {
           value: 'foo'
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
 
       var newValue = 'bar';
@@ -244,8 +225,7 @@ describe('Metadata editor view', function() {
       expect(model.get('metadata').foo).to.equal(newValue);
     });
 
-    it('saves changes to model on textarea element change (TODO)', function() {
-      var model = mockFile();
+    it('saves changes to model on textarea blur (TODO)', function() {
       model.set('defaults', [{
         name: 'foo',
         field: {
@@ -253,7 +233,6 @@ describe('Metadata editor view', function() {
           value: 'foo',
         }
       }]);
-      metadataEditor.model = model;
       metadataEditor.render();
 
       // Attaching a spy to updateModel lets us know later that
@@ -269,7 +248,65 @@ describe('Metadata editor view', function() {
       // Did the view know to update it's model?
       // expect(spy.called);
 
-      expect( model.get('metadata').foo).to.equal(newValue);
+      expect(model.get('metadata').foo).to.equal(newValue);
     });
+
+    it('saves changes to model on checkboxes', function() {
+      model.set('defaults', [{
+        name: 'checkbox',
+        field: {
+          element: 'checkbox',
+          label: 'checkbox label',
+          value: false
+        }
+      }]);
+      metadataEditor.render();
+      var $input = $('#meta').find('input[name="checkbox"]');
+      $input[0].checked = true;
+      $input.trigger('change');
+      expect(model.get('metadata').checkbox).to.equal(true);
+    });
+
+    it('saves changes to model on selects', function() {
+      model.set('defaults', [{
+        name: 'select',
+        field: {
+          element: 'select',
+          label: 'select label',
+          options: [
+            {name: 'Dan', value: 'dan'},
+            {name: 'Jon', value: 'jon'},
+            {name: 'Sre', value: 'sre'}
+          ]
+        }
+      }]);
+      metadataEditor.render();
+      var $select = $('#meta').find('select');
+      $select[0].selectedIndex=1;
+      $select.trigger('liszt:updated').trigger('change');
+      expect(model.get('metadata').select).to.equal('jon');
+    });
+
+    it('saves changes to model on multiselects', function() {
+      model.set('defaults', [{
+        name: 'select',
+        field: {
+          element: 'multiselect',
+          label: 'multiselect label',
+          options: [
+            {name: 'Dan', value: 'dan'},
+            {name: 'Jon', value: 'jon'},
+            {name: 'Sre', value: 'sre'}
+          ]
+        }
+      }]);
+      metadataEditor.render();
+      var $select = $('#meta').find('select');
+      $select[0].selectedIndex=2;
+      $select.trigger('liszt:updated').trigger('change');
+      expect(model.get('metadata').select).to.equal('sre');
+    });
+
+    // TODO no point creating a button test as it work yet.
   });
 });

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -73,7 +73,7 @@ describe('Metadata editor view', function() {
       }]);
       metadataEditor.render();
       expect($('#meta').find('label[for="foo"]').text()).to.equal('bar');
-      expect(metadataEditor.foo.getValue()).to.equal('123');
+      expect(metadataEditor.codeMirrorInstances.foo.getValue()).to.equal('123');
     });
 
     it('creates a select element with correct label and options', function() {
@@ -190,10 +190,8 @@ describe('Metadata editor view', function() {
       expect(metadataEditor.model.get('metadata').layout).to.equal('fixed');
     });
 
-    // Metadata object saves references to code-mirror'd textarea elements
-    // on itself, or 'this', during render function.
-    // This has the potential to overwrite native methods.
-    it('textarea names do not collide with view methods (TODO)', function() {
+    it('textarea names do not collide with view methods', function() {
+      var view = metadataEditor.view;
       model.set('defaults', [{
         name: 'view',
         field: {
@@ -201,7 +199,7 @@ describe('Metadata editor view', function() {
         }
       }]);
       metadataEditor.render();
-      expect( metadataEditor.view).to.deep.equal(view);
+      expect(metadataEditor.view).to.deep.equal(view);
     });
   });
 
@@ -226,7 +224,7 @@ describe('Metadata editor view', function() {
       expect(model.get('metadata').foo).to.equal(newValue);
     });
 
-    it('saves changes to model on textarea blur (TODO)', function() {
+    it('saves changes to model on textarea blur', function() {
       model.set('defaults', [{
         name: 'textarea',
         field: {
@@ -235,7 +233,7 @@ describe('Metadata editor view', function() {
         }
       }]);
       metadataEditor.render();
-      metadataEditor.textarea.setValue('bar');
+      metadataEditor.codeMirrorInstances.textarea.setValue('bar');
       $('.metafield').trigger('change');
       expect(model.get('metadata').textarea).to.equal('bar');
     });
@@ -341,7 +339,7 @@ describe('Metadata editor view', function() {
         textarea: 'abc'
       });
       metadataEditor.render();
-      expect(metadataEditor.textarea.getValue()).to.equal('abc');
+      expect(metadataEditor.codeMirrorInstances.textarea.getValue()).to.equal('abc');
     });
 
     it('sets values on select elements', function() {
@@ -403,7 +401,7 @@ describe('Metadata editor view', function() {
         text: 'hello world'
       });
       metadataEditor.render();
-      expect(jsyaml.safeLoad(metadataEditor.rawEditor.getValue()))
+      expect(jsyaml.safeLoad(metadataEditor.codeMirrorInstances.rawEditor.getValue()))
         .to.deep.equal({text: 'hello world'});
     });
 
@@ -420,7 +418,7 @@ describe('Metadata editor view', function() {
         title: 'hello world'
       });
       metadataEditor.render();
-      expect(metadataEditor.rawEditor.getValue()).to.equal('');
+      expect(metadataEditor.codeMirrorInstances.rawEditor.getValue()).to.equal('');
     });
 
     it('handles text elements with duplicate names', function() {

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -307,6 +307,22 @@ describe('Metadata editor view', function() {
       expect(model.get('metadata').select).to.equal('sre');
     });
 
+    it('saves number fields as numbers', function() {
+      model.set('defaults', [{
+        name: 'number',
+        field: {
+          element: 'number',
+          label: 'number label',
+          value: 4
+        }
+      }]);
+      metadataEditor.render();
+      var $input = $('#meta').find('input[name="number"]')
+      $input.val(6);
+      $input.trigger('change');
+      expect(model.get('metadata').number).to.equal(6);
+    });
+
     // TODO no point creating a button test as it work yet.
   });
 });

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -143,9 +143,7 @@ describe('Metadata editor view', function() {
       expect($('#meta').find('label[for="number"]').text()).to.equal('number label');
     });
 
-    it('creates a button element (TODO)', function() {
-      // TODO this models broken behavior.
-      // https://github.com/prose/prose/issues/859
+    it('creates a button element that defaults to on (true)', function() {
       model.set('defaults', [{
         name: 'button',
         field: {
@@ -155,7 +153,10 @@ describe('Metadata editor view', function() {
         }
       }]);
       metadataEditor.render();
-      expect($('#meta').find('input[type="button"]').length).to.equal(1);
+      var $button = $('#meta').find('[name="button"]');
+      expect($button.length).to.equal(1);
+      expect($button.val()).to.equal('on');
+      expect($button.text()).to.equal('on');
     });
 
     it('creates a text element if no field object exists', function() {
@@ -204,7 +205,7 @@ describe('Metadata editor view', function() {
   });
 
 
-  describe('getting values from form elements', function() {
+  describe('testing user input from form elements', function() {
     // Although there are separate tests for getting values from each meta element individually,
     // this one is more about the ability of this one to save values to a metadata object.
 
@@ -294,6 +295,7 @@ describe('Metadata editor view', function() {
       expect(model.get('metadata').select[0]).to.equal('sre');
     });
 
+
     it('saves number fields as numbers', function() {
       model.set('defaults', [{
         name: 'number',
@@ -310,7 +312,21 @@ describe('Metadata editor view', function() {
       expect(model.get('metadata').number).to.equal(6);
     });
 
-    // TODO no point creating a button test as it work yet.
+    it('saves button values as boolean, defaulting to true', function() {
+      model.set('defaults', [{
+        name: 'button',
+        field: {
+          element: 'button',
+          on: 'on',
+          off: 'off'
+        }
+      }]);
+      metadataEditor.render();
+      var $button = $('#meta').find('[name="button"]');
+      expect(model.get('metadata').button).to.equal(true);
+      $button.trigger('click');
+      expect(model.get('metadata').button).to.equal(false);
+    });
   });
 
   describe('setting defaults on load', function() {

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -39,10 +39,10 @@ describe('Metadata editor view', function() {
     // Without any defaults, we should only see the raw meta element
     it('shows a raw editor', function() {
       metadataEditor.render();
-      expect( $('#meta').find('.form-item').length ).to.equal(1);
+      expect($('#meta').find('.form-item').length).to.equal(1);
     });
 
-    it('creates a text input element with proper default value and label', function() {
+    it('creates a text input element with proper default value, label and data-type', function() {
       var model = mockFile();
       model.set('defaults', [{
         name: 'text',
@@ -54,9 +54,11 @@ describe('Metadata editor view', function() {
       }]);
       metadataEditor.model = model;
       metadataEditor.render();
-      expect( $('#meta').find('input[type="text"]').length ).to.equal(1);
-      expect( $('#meta').find('input[type="text"]').val() ).to.equal('hello world');
-      expect( $('#meta').find('label[for="text"]').text() ).to.equal('text label');
+      var $meta = $('#meta').find('input[type="text"]');
+      expect($meta.length).to.equal(1);
+      expect($meta.val()).to.equal('hello world');
+      expect($meta.data('type')).to.equal('text');
+      expect($('#meta').find('label[for="text"]').text()).to.equal('text label');
     });
 
     it('creates a textarea element with proper default value and label', function() {
@@ -71,8 +73,28 @@ describe('Metadata editor view', function() {
       }]);
       metadataEditor.model = model;
       metadataEditor.render();
-      expect( $('#meta').find('label[for="foo"]').text() ).to.equal('bar');
-      expect( metadataEditor.foo.getValue() ).to.equal('123');
+      expect($('#meta').find('label[for="foo"]').text()).to.equal('bar');
+      expect(metadataEditor.foo.getValue()).to.equal('123');
+    });
+
+    it('creates a select element with proper label and correct options', function() {
+      var model = mockFile();
+      model.set('defaults', [{
+        name: 'select',
+        field: {
+          element: 'select',
+          label: 'select label',
+          options: [
+            {name: 'Dan', value: 'dan'},
+            {name: 'Jon', value: 'jon'},
+            {name: 'Sre', value: 'sre'}
+          ]
+        }
+      }]);
+      metadataEditor.model = model;
+      metadataEditor.render();
+      expect($('#meta').find('label[for="select"]').text()).to.equal('select label');
+      expect($('#meta').find('ul.chzn-results').find('li').length).to.equal(3);
     });
 
     it('creates a multiselect element with proper label and correct options', function() {
@@ -90,8 +112,8 @@ describe('Metadata editor view', function() {
       }]);
       metadataEditor.model = model;
       metadataEditor.render();
-      expect( $('#meta').find('label[for="multiselect"]').text() ).to.equal('multiselect label');
-      expect( $('#meta').find('ul.chzn-results').find('li').length ).to.equal(2);
+      expect($('#meta').find('label[for="multiselect"]').text()).to.equal('multiselect label');
+      expect($('#meta').find('ul.chzn-results').find('li').length).to.equal(2);
     });
 
     it('creates a checkbox element with proper default value and label', function() {
@@ -101,14 +123,33 @@ describe('Metadata editor view', function() {
         field: {
           element: 'checkbox',
           label: 'checkbox label',
-          vale: false
+          value: false
         }
       }]);
       metadataEditor.model = model;
       metadataEditor.render();
-      expect( $('#meta').find('input[type="checkbox"]').length ).to.equal(1);
-      expect( $('#meta').find('input[type="checkbox"]:checked').length ).to.equal(0);
-      expect( $('#meta').find('label[for="checkbox"]').text() ).to.equal('checkbox label');
+      expect($('#meta').find('input[type="checkbox"]').length).to.equal(1);
+      expect($('#meta').find('input[type="checkbox"]:checked').length).to.equal(0);
+      expect($('#meta').find('label[for="checkbox"]').text()).to.equal('checkbox label');
+    });
+
+    it('creates a number element with proper default value, label, and data-type', function() {
+      var model = mockFile();
+      model.set('defaults', [{
+        name: 'number',
+        field: {
+          element: 'number',
+          label: 'number label',
+          value: 4
+        }
+      }]);
+      metadataEditor.model = model;
+      metadataEditor.render();
+      var $meta = $('#meta').find('input[type="text"]');
+      expect($meta.length).to.equal(1);
+      expect($meta.val()).to.equal('4');
+      expect($meta.data('type')).to.equal('number');
+      expect($('#meta').find('label[for="number"]').text()).to.equal('number label');
     });
 
     it('creates a button element (TODO)', function() {
@@ -125,7 +166,17 @@ describe('Metadata editor view', function() {
       }]);
       metadataEditor.model = model;
       metadataEditor.render();
-      expect( $('#meta').find('input[type="button"]').length ).to.equal(1);
+      expect($('#meta').find('input[type="button"]').length).to.equal(1);
+    });
+
+    it('creates a text element if no field object exists', function() {
+      var model = mockFile();
+      model.set('defaults', [{
+        name: 'shouldBeText'
+      }]);
+      metadataEditor.model = model;
+      metadataEditor.render();
+      expect($('#meta').find('input[type="text"]').length).to.equal(1);
     });
 
     it('does not append hidden meta elements', function() {
@@ -139,7 +190,21 @@ describe('Metadata editor view', function() {
       }]);
       metadataEditor.model = model;
       metadataEditor.render();
-      expect( $('#meta').find('.form-item').length ).to.equal(1);
+      expect($('#meta').find('.form-item').length).to.equal(1);
+    });
+
+    it('saves defaults that are hidden to metadata', function() {
+      var model = mockFile();
+      model.set('defaults', [{
+        name: 'layout',
+        field: {
+          element: 'hidden',
+          value: 'fixed'
+        }
+      }]);
+      metadataEditor.model = model;
+      metadataEditor.render();
+      expect(metadataEditor.model.get('metadata').layout).to.equal('fixed');
     });
 
     // Metadata object saves references to code-mirror'd textarea elements
@@ -155,7 +220,7 @@ describe('Metadata editor view', function() {
       }]);
       metadataEditor.model = model;
       metadataEditor.render();
-      expect( metadataEditor.view ).to.deep.equal(view);
+      expect( metadataEditor.view).to.deep.equal(view);
     });
   });
 
@@ -204,7 +269,7 @@ describe('Metadata editor view', function() {
       // Did the view know to update it's model?
       // expect(spy.called);
 
-      expect( model.get('metadata').foo ).to.equal(newValue);
+      expect( model.get('metadata').foo).to.equal(newValue);
     });
   });
 });

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -439,6 +439,37 @@ describe('Metadata editor view', function() {
       metadataEditor.render();
       expect(model.get('metadata').text).to.deep.equal(['hello', 'world']);
     });
-  });
 
+    it('adds options to selects from metadata when none exists in defaults', function() {
+      model.set('defaults', [{
+        name: 'select',
+        field: {
+          element: 'select',
+          options: []
+        }
+      }]);
+      model.set('metadata', {
+        select: 'foo'
+      });
+      metadataEditor.render();
+      expect($('#meta').find('select').find('option').length).to.equal(1);
+      expect(model.get('metadata').select).to.equal('foo');
+    });
+
+    it('adds options to multiselects from metadata when none exists in defaults', function() {
+      model.set('defaults', [{
+        name: 'multiselect',
+        field: {
+          element: 'multiselect',
+          options: []
+        }
+      }]);
+      model.set('metadata', {
+        multiselect: ['foo', 'bar']
+      });
+      metadataEditor.render();
+      expect($('#meta').find('select').find('option').length).to.equal(2);
+      expect(model.get('metadata').multiselect).to.deep.equal(['foo', 'bar']);
+    });
+  });
 });


### PR DESCRIPTION
Fixes a number of issues relating to saving and loading metadata from liquid tags.

Includes a major refactor of `app/views/metadata.js`. A big part of this refactor is pushing out the logic of creating, setting, and getting values from form elements into separate views, which are now located in `app/views/meta/`.

Also substantially improves test coverage for the metadata editor and associated form elements. Right now the tests are failing because button form elements I found to be broken, and this fix does not include that (yet) - see #859.

This should address the following tickets:
#836 
#766 
#623 
#582 

Because this is a pretty big refactor, I would love for people to pull this down and test against their own prose configurations, as I continue to test this in the coming days. Please post any bug findings here.

cc @mikemorris @tristen @anandthakker @phillipadsmith @dhcole