### PR TITLE
check for config before using. Extract defaultPath method

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -1278,17 +1278,21 @@ module.exports = Backbone.View.extend({
     };
   },
 
+  defaultUploadPath: function(fileName) {
+    // Default to media directory if defined in config,
+    // current directory if no path specified
+    var dir = (this.config && this.config.media) ? this.config.media :
+      util.extractFilename(this.model.get('path'))[0];
+
+    return _.compact([dir, fileName]).join('/');
+  },
+
   upload: function(e, file, content, path) {
     // Loading State
     this.updateSaveState(t('actions.upload.uploading', { file: file.name }), 'saving');
 
-    // Default to media directory if defined in config,
-    // current directory if no path specified
-    var dir = this.config.media ? this.config.media :
-      util.extractFilename(this.model.get('path'))[0];
-    path = path || _.compact([dir, file.name]).join('/');
-
-    this.collection.upload(file, content, path, {
+    var uploadPath = path || this.defaultUploadPath(file.name);
+    this.collection.upload(file, content, uploadPath, {
       success: (function(model, res, options) {
         var name = res.content.name;
         var path = '{{site.baseurl}}/' + res.content.path;

--- a/test/spec/views/file.js
+++ b/test/spec/views/file.js
@@ -46,6 +46,29 @@ describe('File view', function() {
       fileView.render();
       expect(fileView.editor.getValue()).to.equal(content)
     })
+
+    describe('#defaulUploadPath', function() {
+        beforeEach(function() {
+            fileView.model = mockFile()
+            fileView.model.set('path', '/path/to/fake.md')
+        });
+        context('with config', function() {
+            beforeEach(function() {
+                fileView.config = { "media": "/configured/assets" };
+            });
+            it('uses the configured upload path', function() {
+                expect(fileView.defaultUploadPath('my-image.jpg')).to.equal("/configured/assets/my-image.jpg");
+            });
+        });
+        context('without config', function() {
+            beforeEach(function() {
+                fileView.config = null;
+            });
+            it('uses the files directory', function() {
+                expect(fileView.defaultUploadPath('my-image.jpg')).to.equal("/path/to/my-image.jpg");
+            });
+        });
+    });
   });
 
   describe('in preview mode', function() {


### PR DESCRIPTION
Currently uploads don't work if config isn't defined, this fixes that in an obtuse way.

Also, extracted (and tested) the defaultPath method.

I'm brand new to the project/codebase so please correct generously. Thanks for your work!

/cc @dereklieu this is what I was working on at Stories LA on Thursday - sorry it took so long. Got distracted by other things.

oh! Also worth noting that 3 tests were failing for me in this PR, but they were also failing in master. 