### PR TITLE
Fix/868 title form

### DIFF
--- a/app/views/header.js
+++ b/app/views/header.js
@@ -109,6 +109,11 @@ module.exports = Backbone.View.extend({
       this.file.set('path', path);
     }
 
+    var metadata = this.file.get('metadata') || {};
+    this.file.set('metadata', _.extend(metadata, {
+      title: e.currentTarget.value
+    }));
+
     this.trigger('makeDirty');
   },
 

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -60,13 +60,12 @@ module.exports = Backbone.View.extend({
 
     var $form = this.$el.find('.form');
 
-    var metadata = this.model.get('metadata');
+    var metadata = this.model.get('metadata') || {};
     var lang = metadata && metadata.lang ? metadata.lang : 'en';
 
     // Using the yml configuration file for metadata,
     // render form fields.
     _.each(this.model.get('defaults'), (function(data, key) {
-      var metadata = this.model.get('metadata') || {};
 
       // Tests that 1. This is the title metadata,
       // and 2. We've decided to combine the title form UI as the page header.
@@ -145,7 +144,7 @@ module.exports = Backbone.View.extend({
             else {
               newMeta[data.name] = newDefault;
             }
-            this.model.set('metadata', _.extend(newMeta, this.model.get('metadata') || {}));
+            this.model.set('metadata', _.extend(newMeta, metadata));
           break;
         }
       }

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -267,11 +267,11 @@ module.exports = Backbone.View.extend({
       metadata.published = false;
     }
 
-    // Get the title value from heading if we need to.
-    if (this.titleAsHeading) {
-      metadata.title = (this.view.header) ?
-        this.view.header.inputGet() :
-        this.model.get('metadata').title[0];
+    // Get the title value from heading if it's available.
+    // In testing environment, if the header doesn't render
+    // then this.view.header is undefined.
+     if (this.titleAsHeading && this.view.header) {
+      metadata.title = this.view.header.inputGet();
     }
 
     // Load any data coming from not defined raw yaml front matter.

--- a/test/index.js
+++ b/test/index.js
@@ -16,4 +16,5 @@ require('./spec/models/file');
 require('./spec/views/file');
 require('./spec/views/metadata');
 require('./spec/views/meta-forms');
+require('./spec/views/header');
 require('./spec/collections/files');

--- a/test/spec/views/header.js
+++ b/test/spec/views/header.js
@@ -1,0 +1,60 @@
+var _ = require('underscore');
+var $ = require('jquery-browserify');
+var HeaderView = require('../../../app/views/header');
+
+var MockFile = require('../../mocks/models/file');
+var MockRepo = require('../../mocks/models/repo');
+
+describe('Header view', function() {
+  var file = MockFile();
+  var repo = MockRepo();
+  var _opt = {
+
+    // what shows up in the title field
+    // input: 'untitled'
+
+    // whether it's a title (markdown with title default) or a path
+    // title: true
+
+    file: file,
+    repo: repo,
+    alterable: true,
+
+    // true if it's a new file
+    placeholder: true
+  };
+  var options;
+
+  beforeEach(function() {
+    var $header = $('<div />', { id: 'header', }).appendTo($('body'));
+    options = _.extend({
+      el: $header
+    }, _opt);
+  });
+
+  afterEach(function() {
+    $('#header').remove();
+  });
+
+  var headerView;
+
+  it('updates metadata to file model on markdown files', function() {
+    options.input = '';
+
+    // will signal that it's markdown.
+    options.title = true;
+    new HeaderView(options).render();
+    $('input[data-mode="title"]').val('foo').trigger('change');
+    expect(file.get('metadata').title).to.equal('foo');
+  });
+
+
+  it('updates path on file model on non-markdown files', function() {
+    options.input = 'some/path/to/where.html';
+
+    options.title = false;
+    new HeaderView(options).render();
+    $('input[data-mode="path"]').val('another/path.html').trigger('change');
+    expect(file.get('path')).to.equal('another/path.html');
+  });
+});

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -21,10 +21,11 @@ describe('Metadata editor view', function() {
     }).appendTo($('body'));
 
     model = mockFile();
+    var fileView = mockFileView();
     metadataEditor = new MetadataView({
       model: model,
-      titleAsHeading: '',
-      view: mockFileView(),
+      titleAsHeading: fileView.titleAsHeading(),
+      view: fileView,
       el: $('#meta')
     });
   });
@@ -326,6 +327,15 @@ describe('Metadata editor view', function() {
       expect(model.get('metadata').button).to.equal(true);
       $button.trigger('click');
       expect(model.get('metadata').button).to.equal(false);
+    });
+
+    it('does not error when titleAsHeading is true and no title is defined on metadata', function() {
+      model.set('metadata', {
+        title: null
+      });
+      metadataEditor.titleAsHeading = true;
+      metadataEditor.render();
+      expect(metadataEditor).to.be.ok;
     });
   });
 


### PR DESCRIPTION
Fixes #868 

Also [fixes a line](https://github.com/prose/prose/compare/fix/868-title-form?expand=1#diff-87da8fed8be49d2c3c6bc84c4d8fb460L274) which had been throwing an error in tests regarding reading the title from `metadata.js`.

Includes tests for saving inputs into the header form.