### PR TITLE
Implementing keyboard shortcut for toggling between edit and preview …

### DIFF
--- a/app/toolbar/markdown.js
+++ b/app/toolbar/markdown.js
@@ -48,6 +48,9 @@ module.exports = function() {
         }, {
           menuName: t('dialogs.help.miscellaneous.content.escaping.title'),
           data: t('dialogs.help.miscellaneous.content.escaping.content')
+        }, {
+            menuName: t('dialogs.help.miscellaneous.content.shortcuts.title'),
+            data: t('dialogs.help.miscellaneous.content.shortcuts.content')
         }]
       }
     ]

--- a/app/views/app.js
+++ b/app/views/app.js
@@ -19,7 +19,7 @@ module.exports = Backbone.View.extend({
   events: {
     'click a.logout': 'logout'
   },
-
+  
   initialize: function(options) {
     _.bindAll(this);
 
@@ -30,6 +30,14 @@ module.exports = Backbone.View.extend({
         } else {
           util.goToFile();
         }
+      }
+    }).bind(this));
+    
+    key('ctrl+enter', (function (e, handler) {
+      if (this.nav.state === 'blob') {
+        this.nav.trigger('edit');
+      } else if (this.nav.state === 'edit') {
+        this.nav.trigger('blob');
       }
     }).bind(this));
 

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -359,6 +359,9 @@ module.exports = Backbone.View.extend({
 
     if (this.model.get('markdown')) {
       return {
+        'Ctrl-Enter': function (codemirror) {
+          self.blob();
+        },
         'Ctrl-S': function(codemirror) {
           self.updateFile();
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prose",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "[Prose](http://prose.io) is a web-based interface for managing text-based content in your GitHub repositories. Use it to create, edit, and delete files, and save your changes directly to GitHub.",
   "dependencies": {
     "backbone": "~1.0.0",

--- a/translations/locales/en.json
+++ b/translations/locales/en.json
@@ -252,6 +252,10 @@
                     "escaping": {
                         "title": "Escaping",
                         "content": "<p>If you want to use a special Markdown character in your document (such as displaying literal asterisks), you can escape the character with the backslash (<code>\\\\</code>). Markdown will ignore the character directly after a backslash.</p>\n"
+                    },
+                    "shortcuts": {
+                        "title": "Shortcuts",
+                        "content": "<p>Press <code>Ctrl-S</code> to commit your changes. <br/> Press <code>Ctrl-Enter</code> to toggle between editing and previewing.</p>\n"
                     }
                 }
             }


### PR DESCRIPTION
…in editor.

I love that the Ctrl-S shortcut is working, but was frustrated about the lack of shortcut for going into preview mode and back to editing mode. 
So I implemented it. I verified on my local deployment that it works.
I picked Ctrl-Enter, but feel free to pick whichever combination works best. The only caveat is that some combinations interfere with the browser (for instance, I was using Ctrl-E at first, which worked but also moved the caret into the URL bar).

Let me know if this is acceptable or if there is anything I can do.

Cheers,
Julien