### PR TITLE
Use npm start to abstract serve

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,7 @@ have [node.js](http://nodejs.org) >= v0.8 installed.
 2. Run `npm install && mkdir -p dist && gulp`
 3. To run prose with authentication locally, a `oauth.json` file is required in the
 root directory. When you run `gulp` this file is created automatically.
-4. `npm install serve -g`
-5. Run `serve` By default, prose will be set up on [http://localhost:3000](http://localhost:3000).
+4. Run `npm start` By default, prose will be set up on [http://localhost:3000](http://localhost:3000).
 
 __Note:__ You should not commit the `oauth.json` file to a remote repo or along with a pull
 request.

--- a/package.json
+++ b/package.json
@@ -39,12 +39,15 @@
     "mocha-phantomjs": "~3.3.2",
     "phantomjs": "~1.9.7-4",
     "request": "~2.16.2",
+    "serve": "^1.4.0",
+    "sinon": "^1.17.2",
     "sinon-chai": "^2.6.0",
     "uglify-js": "~2.2.5",
     "vinyl-source-stream": "^0.1.1"
   },
   "scripts": {
-    "test": "node_modules/.bin/gulp && node_modules/.bin/mocha-phantomjs test/index.html"
+    "test": "node_modules/.bin/gulp && node_modules/.bin/mocha-phantomjs test/index.html",
+    "start": "serve"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Instead of requiring users to install `serve` globally and use that command to run a server, this uses the standard command `npm start`. Note that npm recognizes globals for you so serve doesn't have to be installed globally.

Also adds the dev dependency `sinon`, the absence of which was causing the build to fail.