### PR TITLE
CSV editor

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -309,16 +309,24 @@ module.exports = Backbone.View.extend({
   },
 
   initCSVEditor: function() {
+    var self = this;
+
     var container = this.$el.find('#csv')[0];
     var data = Papa.parse(this.model.get('content'), {
       header: true,
       skipEmptyLines: true
     });
-    console.log('data', data)
+
     this.editor = new Handsontable(container, {
       data: data.data,
       colHeaders: data.meta.fields,
-      stretchH: 'all'
+      stretchH: 'all',
+      afterChange: function(changes, source) {
+        if (source !== 'loadData') self.makeDirty()
+      },
+      getValue: function() {
+        return Papa.unparse(this.getSourceData());
+      }
     });
   },
 

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -3,7 +3,7 @@ var _ = require('underscore');
 var queue = require('queue-async');
 var jsyaml = require('js-yaml');
 var patch = require('../../vendor/liquid.patch');
-var Handsontable = require('handsontable/dist/handsontable.full.min');
+var Handsontable = require('handsontable');
 var Papa = require('papaparse');
 
 var ModalView = require('./modal');

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -336,9 +336,7 @@ module.exports = Backbone.View.extend({
 
     this.editor.setValue = function(newValue) {
       var parsedValue = self.parseCSV(newValue)
-      console.log('setValue', newValue, parsedValue)
       this.loadData(parsedValue.data)
-      // this.render()
     };
 
     // Check sessionStorage for existing stash

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -310,7 +310,6 @@ module.exports = Backbone.View.extend({
 
   parseCSV: function(csvString) {
     return Papa.parse(util.trim(csvString), {  // remove trailing whitespace, mholt/PapaParse#279
-      header: true,
       skipEmptyLines: true
     });
   },
@@ -323,8 +322,12 @@ module.exports = Backbone.View.extend({
 
     this.editor = new Handsontable(container, {
       data: data.data,
-      colHeaders: data.meta.fields,
+      colHeaders: true,
+      rowHeaders: true,
       stretchH: 'all',
+      fixedRowsTop: 1,
+      contextMenu: ['row_above', 'row_below', 'col_left', 'col_right', 'remove_row', 'remove_col', 'undo', 'redo'],
+      undo: true,
       afterChange: function(changes, source) {
         if (source !== 'loadData') self.makeDirty()
       }

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -331,7 +331,7 @@ module.exports = Backbone.View.extend({
       contextMenu: ['row_above', 'row_below', 'col_left', 'col_right', 'remove_row', 'remove_col', 'undo', 'redo'],
       undo: true,
       afterChange: function(changes, source) {
-        if (source !== 'loadData') self.makeDirty()
+        if (source !== 'loadData') self.makeDirty();
       }
     })
 
@@ -340,8 +340,9 @@ module.exports = Backbone.View.extend({
     };
 
     this.editor.setValue = function(newValue) {
-      var parsedValue = self.parseCSV(newValue)
-      this.loadData(parsedValue.data)
+      var parsedValue = self.parseCSV(newValue);
+      this.loadData(parsedValue.data);
+      self.makeDirty();
     };
 
     // Check sessionStorage for existing stash

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -309,7 +309,7 @@ module.exports = Backbone.View.extend({
   },
 
   parseCSV: function(csvString) {
-    return Papa.parse(csvString, {
+    return Papa.parse(util.trim(csvString), {  // remove trailing whitespace, mholt/PapaParse#279
       header: true,
       skipEmptyLines: true
     });
@@ -559,7 +559,7 @@ module.exports = Backbone.View.extend({
       this.config = this.model.get('collection').config;
 
       // initialize the subviews
-      if (this.model.get('lang') === 'csv') {
+      if (['csv', 'tsv'].indexOf(this.model.get('lang')) !== -1) {
         this.initCSVEditor();
       } else {
         this.initEditor();

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -308,14 +308,18 @@ module.exports = Backbone.View.extend({
     return _.escape(content);
   },
 
+  parseCSV: function(csvString) {
+    return Papa.parse(csvString, {
+      header: true,
+      skipEmptyLines: true
+    });
+  },
+
   initCSVEditor: function() {
     var self = this;
 
     var container = this.$el.find('#csv')[0];
-    var data = Papa.parse(this.model.get('content'), {
-      header: true,
-      skipEmptyLines: true
-    });
+    var data = this.parseCSV(this.model.get('content'))
 
     this.editor = new Handsontable(container, {
       data: data.data,
@@ -323,11 +327,23 @@ module.exports = Backbone.View.extend({
       stretchH: 'all',
       afterChange: function(changes, source) {
         if (source !== 'loadData') self.makeDirty()
-      },
-      getValue: function() {
-        return Papa.unparse(this.getSourceData());
       }
-    });
+    })
+
+    this.editor.getValue = function() {
+      return Papa.unparse(this.getSourceData());
+    };
+
+    this.editor.setValue = function(newValue) {
+      var parsedValue = self.parseCSV(newValue)
+      console.log('setValue', newValue, parsedValue)
+      this.loadData(parsedValue.data)
+      // this.render()
+    };
+
+    // Check sessionStorage for existing stash
+    // Apply if stash exists and is current, remove if expired
+    this.stashApply();
   },
 
   initEditor: function() {

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -326,6 +326,8 @@ module.exports = Backbone.View.extend({
       rowHeaders: true,
       stretchH: 'all',
       fixedRowsTop: 1,
+      manualColumnResize: true,
+      manualRowResize: true,
       contextMenu: ['row_above', 'row_below', 'col_left', 'col_right', 'remove_row', 'remove_col', 'undo', 'redo'],
       undo: true,
       afterChange: function(changes, source) {

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -592,9 +592,8 @@ module.exports = Backbone.View.extend({
       var jekyll = /^(_posts|_drafts)/.test(this.model.get('path'));
 
       // Update the navigation view with menu options
-      // if a file contains metadata, has default metadata or is Markdown
-      if (this.model.get('metadata') || this.model.get('defaults') ||
-        (markdown && jekyll)) {
+      // if a file contains metadata, has default metadata or is Markdown (except CSVs)
+      if (!file.useCSVEditor && (this.model.get('metadata') || this.model.get('defaults') || (markdown && jekyll))) {
         this.renderMetadata();
 
         mode.push('meta');

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -323,14 +323,20 @@ module.exports = Backbone.View.extend({
   initCSVEditor: function() {
     var self = this;
 
-    var container = this.$el.find('#csv')[0];
+    var $container = this.$el.find('#csv');
+    var container = $container[0];
     var data = this.parseCSV(this.model.get('content'))
+
+    var distanceFromTop = $container.offset().top;
+    var documentHeight = $(document).height();
+    var editorHeight = documentHeight - distanceFromTop;
 
     this.editor = new Handsontable(container, {
       data: data.data,
       colHeaders: true,
       rowHeaders: true,
       stretchH: 'all',
+      height: editorHeight,
       fixedRowsTop: 1,
       manualColumnResize: true,
       manualRowResize: true,

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -58,6 +58,7 @@ module.exports = Backbone.View.extend({
 
     // Events from sidebar
     this.listenTo(this.sidebar, 'destroy', this.destroy);
+    this.listenTo(this.sidebar, 'toggle-editor', this.toggleEditor);
     this.listenTo(this.sidebar, 'draft', this.draft);
     this.listenTo(this.sidebar, 'cancel', this.cancel);
     this.listenTo(this.sidebar, 'confirm', this.updateFile);
@@ -308,6 +309,11 @@ module.exports = Backbone.View.extend({
     return _.escape(content);
   },
 
+  toggleEditor: function() {
+    this.disableCSVEditor = !this.disableCSVEditor;
+    this.render();
+  },
+
   parseCSV: function(csvString) {
     return Papa.parse(util.trim(csvString), {  // remove trailing whitespace, mholt/PapaParse#279
       skipEmptyLines: true
@@ -554,7 +560,8 @@ module.exports = Backbone.View.extend({
 
       var file = {
         markdown: this.model.get('markdown'),
-        lang: this.model.get('lang')
+        lang: this.model.get('lang'),
+        useCSVEditor: (['csv', 'tsv'].indexOf(this.model.get('lang')) !== -1 && !this.disableCSVEditor)
       };
 
       this.$el.empty().append(_.template(this.template, file, {
@@ -565,7 +572,7 @@ module.exports = Backbone.View.extend({
       this.config = this.model.get('collection').config;
 
       // initialize the subviews
-      if (['csv', 'tsv'].indexOf(this.model.get('lang')) !== -1) {
+      if (file.useCSVEditor) {
         this.initCSVEditor();
       } else {
         this.initEditor();

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -310,7 +310,7 @@ module.exports = Backbone.View.extend({
   },
 
   toggleEditor: function() {
-    this.disableCSVEditor = !this.disableCSVEditor;
+    cookie.set('disableCSVEditor', !cookie.get('disableCSVEditor'))
     this.render();
   },
 
@@ -561,7 +561,7 @@ module.exports = Backbone.View.extend({
       var file = {
         markdown: this.model.get('markdown'),
         lang: this.model.get('lang'),
-        useCSVEditor: (['csv', 'tsv'].indexOf(this.model.get('lang')) !== -1 && !this.disableCSVEditor)
+        useCSVEditor: (['csv', 'tsv'].indexOf(this.model.get('lang')) !== -1 && !cookie.get('disableCSVEditor'))
       };
 
       this.$el.empty().append(_.template(this.template, file, {

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -3,6 +3,8 @@ var _ = require('underscore');
 var queue = require('queue-async');
 var jsyaml = require('js-yaml');
 var patch = require('../../vendor/liquid.patch');
+var Handsontable = require('handsontable/dist/handsontable.full.min');
+var Papa = require('papaparse');
 
 var ModalView = require('./modal');
 var marked = require('marked');
@@ -306,6 +308,20 @@ module.exports = Backbone.View.extend({
     return _.escape(content);
   },
 
+  initCSVEditor: function() {
+    var container = this.$el.find('#csv')[0];
+    var data = Papa.parse(this.model.get('content'), {
+      header: true,
+      skipEmptyLines: true
+    });
+    console.log('data', data)
+    this.editor = new Handsontable(container, {
+      data: data.data,
+      colHeaders: data.meta.fields,
+      stretchH: 'all'
+    });
+  },
+
   initEditor: function() {
     var lang = this.model.get('lang');
 
@@ -509,7 +525,8 @@ module.exports = Backbone.View.extend({
       var content = this.model.get('content');
 
       var file = {
-        markdown: this.model.get('markdown')
+        markdown: this.model.get('markdown'),
+        lang: this.model.get('lang')
       };
 
       this.$el.empty().append(_.template(this.template, file, {
@@ -520,7 +537,11 @@ module.exports = Backbone.View.extend({
       this.config = this.model.get('collection').config;
 
       // initialize the subviews
-      this.initEditor();
+      if (this.model.get('lang') === 'csv') {
+        this.initCSVEditor();
+      } else {
+        this.initEditor();
+      }
       this.initHeader();
       this.initToolbar();
       this.initSidebar();

--- a/app/views/sidebar/settings.js
+++ b/app/views/sidebar/settings.js
@@ -10,6 +10,7 @@ module.exports = Backbone.View.extend({
 
   events: {
     'click a.delete': 'emit',
+    'click a.toggle-editor': 'emit',
     'click a.translate': 'emit',
     'click a.draft': 'emit',
     'change input.filepath': 'setPath'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -129,7 +129,10 @@ gulp.task('build-tests', ['templates', 'oauth', 'vendor'], function() {
 
   // Browserify index.js
   // Pass `debug` option to enable source maps.
-  return browserify({debug: true})
+  return browserify({
+    debug: true,
+    noParse: [require.resolve('handsontable/dist/handsontable.full')]
+  })
     .add('./test/index.js')
     .external(['chai', 'mocha'])
     .bundle()
@@ -144,7 +147,9 @@ gulp.task('build-app', ['templates', 'oauth', 'vendor'], function() {
 
 
   // Browserify app scripts.
-  return browserify()
+  return browserify({
+    noParse: [require.resolve('handsontable/dist/handsontable.full')]
+  })
     .add('./app/boot.js')
     .bundle()
     .pipe(source('app.js'))

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <link rel='apple-touch-icon' sizes="72x72" href='./img/prose@72.png' />
   <link rel='apple-touch-icon' sizes="114x114" href='./img/prose@114.png' />
   <link rel='apple-touch-icon' sizes="144x144" href='./img/prose@144.png' />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/handsontable/0.20.2/handsontable.full.min.css">
   <link rel='stylesheet' href='./style.css'>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
 </head>
 <body>
   <div id='prose'></div>
+  <script src='https://cdnjs.cloudflare.com/ajax/libs/handsontable/0.20.2/handsontable.full.min.js'></script>
   <script src='locale.js'></script>
   <script src='dist/prose.js'></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
 </head>
 <body>
   <div id='prose'></div>
-  <script src='https://cdnjs.cloudflare.com/ajax/libs/handsontable/0.20.2/handsontable.full.min.js'></script>
   <script src='locale.js'></script>
   <script src='dist/prose.js'></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "chrono": "~1.0.4",
     "deepmerge": "~0.2.7",
     "diff": "~1.0.4",
+    "handsontable": "git://github.com/handsontable/handsontable.git#0.20.2",
     "ignore": "~2.2.7",
     "jquery-browserify": "~1.8.1",
     "js-base64": "~2.1.1",
@@ -56,8 +57,10 @@
     ]
   },
   "browserify-shim": {
-    "chai": "global:chai",
-    "handsontable": "global:Handsontable"
+    "chai": "global:chai"
+  },
+  "browser": {
+    "handsontable": "handsontable/dist/handsontable.full"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "chrono": "~1.0.4",
     "deepmerge": "~0.2.7",
     "diff": "~1.0.4",
-    "handsontable": "git://github.com/handsontable/handsontable.git#0.20.2",
     "ignore": "~2.2.7",
     "jquery-browserify": "~1.8.1",
     "js-base64": "~2.1.1",
@@ -57,7 +56,8 @@
     ]
   },
   "browserify-shim": {
-    "chai": "global:chai"
+    "chai": "global:chai",
+    "handsontable": "global:Handsontable"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "chrono": "~1.0.4",
     "deepmerge": "~0.2.7",
     "diff": "~1.0.4",
+    "handsontable": "github:handsontable/handsontable",
     "ignore": "~2.2.7",
     "jquery-browserify": "~1.8.1",
     "js-base64": "~2.1.1",
@@ -15,6 +16,7 @@
     "keymaster": "git://github.com/madrobby/keymaster.git#0f09fc1b7e66c2b7e07afe89a419366dcf2d1cd8",
     "marked": "~0.2.8",
     "mkdirp": "^0.5.0",
+    "papaparse": "^4.1.2",
     "queue-async": "~1.0.3",
     "underscore": "~1.4.4"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "chrono": "~1.0.4",
     "deepmerge": "~0.2.7",
     "diff": "~1.0.4",
-    "handsontable": "github:handsontable/handsontable",
+    "handsontable": "git://github.com/handsontable/handsontable.git#0.20.2",
     "ignore": "~2.2.7",
     "jquery-browserify": "~1.8.1",
     "js-base64": "~2.1.1",

--- a/style.css
+++ b/style.css
@@ -302,6 +302,12 @@ textarea#code {
     border-width:1px;
     }
 
+div#csv-container {
+  width: 100%;
+  height: 600px;
+  overflow: hidden;
+}
+
 ::-webkit-input-placeholder { color:#a8afb2; }
 ::-moz-placeholder          { color:#a8afb2; }
 :-ms-input-placeholder      { color:#a8afb2; }

--- a/style.css
+++ b/style.css
@@ -304,7 +304,6 @@ textarea#code {
 
 div#csv-container {
   width: 100%;
-  height: 600px;
   overflow: hidden;
 }
 

--- a/templates/file.html
+++ b/templates/file.html
@@ -18,7 +18,9 @@
       </div>
       <div id='drop' class='drop-mask'></div>
       <% if (file.lang === 'csv') { %>
-      <div id='csv'></div>
+      <div id='csv-container'>
+        <div id='csv'></div>
+      </div>
       <% } else { %>
       <textarea id='code' class='code round inner'></textarea>
       <% } %>

--- a/templates/file.html
+++ b/templates/file.html
@@ -17,7 +17,7 @@
         </div>
       </div>
       <div id='drop' class='drop-mask'></div>
-      <% if (file.lang === 'csv') { %>
+      <% if (['csv', 'tsv'].indexOf(file.lang) !== -1) { %>
       <div id='csv-container'>
         <div id='csv'></div>
       </div>

--- a/templates/file.html
+++ b/templates/file.html
@@ -17,7 +17,7 @@
         </div>
       </div>
       <div id='drop' class='drop-mask'></div>
-      <% if (['csv', 'tsv'].indexOf(file.lang) !== -1) { %>
+      <% if (file.useCSVEditor) { %>
       <div id='csv-container'>
         <div id='csv'></div>
       </div>

--- a/templates/file.html
+++ b/templates/file.html
@@ -17,7 +17,11 @@
         </div>
       </div>
       <div id='drop' class='drop-mask'></div>
+      <% if (file.lang === 'csv') { %>
+      <div id='csv'></div>
+      <% } else { %>
       <textarea id='code' class='code round inner'></textarea>
+      <% } %>
     </div>
     <div id='preview' class='view preview prose'></div>
   </div>

--- a/templates/sidebar/settings.html
+++ b/templates/sidebar/settings.html
@@ -13,6 +13,10 @@
       <% } %>
     <% }); %>
   <% } %>
+  
+  <% if (['csv', 'tsv'].indexOf(settings.lang) !== -1) { %>
+    <a class='toggle-editor button round' href='#' data-action='toggle-editor'><%= t('sidebar.settings.toggleEditor') %></a>
+  <% } %>
 
   <!-- if !isNew() and is writable -->
   <a class='delete button round' href='#' data-action='destroy'><%= t('sidebar.settings.delete') %></a>

--- a/test/spec/views/file.js
+++ b/test/spec/views/file.js
@@ -47,6 +47,30 @@ describe('File view', function() {
       expect(fileView.editor.getValue()).to.equal(content)
     })
 
+    it('creates the Hansontable editor', function() {
+      fileView.model = mockFile();
+      fileView.model.set('lang', 'csv');
+      fileView.collection = fileView.model.collection;
+      fileView.render();
+      expect(fileView.editor.constructor.name).to.be('Handsontable');
+    })
+
+    it('initializes Handsontable with the file\'s contents as structured data', function() {
+      var content = 'a,b \r\nfoo,bar';
+      fileView.model = mockFile(content);
+      fileView.collection = fileView.model.collection;
+      fileView.render();
+      expect(fileView.editor.getSourceData()).to.equal([['a', 'b'], ['foo', 'bar']]);
+    })
+
+    it('retrieves Handsontable contents as a string', function() {
+      var content = 'a,b \r\nfoo,bar';
+      fileView.model = mockFile(content);
+      fileView.collection = fileView.model.collection;
+      fileView.render();
+      expect(fileView.editor.getValue()).to.equal(content);
+    })
+
     it('creates a placeholder title for new files', function() {
       fileView.model = mockFile();
       fileView.model.set({

--- a/test/spec/views/file.js
+++ b/test/spec/views/file.js
@@ -4,7 +4,8 @@ var FileView = require('../../../app/views/file'),
     mockRepo = require('../../mocks/models/repo'),
     mockFile = require('../../mocks/models/file'),
     mockApp = require('../../mocks/views/app'),
-    mockRouter = require('../../mocks/router');
+    mockRouter = require('../../mocks/router'),
+    Handsontable = require('handsontable');
 
 
 describe('File view', function() {
@@ -52,20 +53,22 @@ describe('File view', function() {
       fileView.model.set('lang', 'csv');
       fileView.collection = fileView.model.collection;
       fileView.render();
-      expect(fileView.editor.constructor.name).to.be('Handsontable');
+      expect(fileView.editor).to.be.an.instanceof(Handsontable.Core);
     })
 
     it('initializes Handsontable with the file\'s contents as structured data', function() {
-      var content = 'a,b \r\nfoo,bar';
+      var content = 'a,b\r\nfoo,bar';
       fileView.model = mockFile(content);
+      fileView.model.set('lang', 'csv');
       fileView.collection = fileView.model.collection;
       fileView.render();
-      expect(fileView.editor.getSourceData()).to.equal([['a', 'b'], ['foo', 'bar']]);
+      expect(fileView.editor.getSourceData()).to.deep.equal([['a', 'b'], ['foo', 'bar']]);
     })
 
     it('retrieves Handsontable contents as a string', function() {
-      var content = 'a,b \r\nfoo,bar';
+      var content = 'a,b\r\nfoo,bar';
       fileView.model = mockFile(content);
+      fileView.model.set('lang', 'csv');
       fileView.collection = fileView.model.collection;
       fileView.render();
       expect(fileView.editor.getValue()).to.equal(content);

--- a/translations/locales/en.json
+++ b/translations/locales/en.json
@@ -168,7 +168,8 @@
             "fileInputLabel": "File Path",
             "delete": "Delete This File",
             "translate": "Translate to",
-            "draft": "Create Draft"
+            "draft": "Create Draft",
+            "toggleEditor": "Toggle Editor"
         }
     },
     "dialogs": {


### PR DESCRIPTION
<img width="735" alt="screen shot 2016-01-02 at 18 01 50" src="https://cloud.githubusercontent.com/assets/761444/12076500/f4cf03b6-b17a-11e5-8686-0004268d9127.png">

Adds a spreadsheet editor for CSV files using [handsontable](http://handsontable.com) and [PapaParse](http://papaparse.com).

It's fully functional but I'd still call it a work in progress as I hope to solicit your feedback before recommending a merge. The following items remain:

* [x] CommonJS dependency (Requiring `handsontable` is tricky because it's written in ES2015. Right now it's pulling in the built, minified file)
* [ ] Get clarity: I wasn't sure the best way to pull in handsontable's CSS - it seems like the only CSS in prose is in `styles.css` - are there no CSS dependencies?
* [x] It should work for TSV files too (PapaParse supports it)
* [x] Auto-height (I don't like that it has a fixed height of `600px`, but in order to get smooth overflow scrolling, handsontable needs a default height. We can compute this based on available vertical real estate, I imagine.)
* [x] Undo/redo support
* [x] Add/Delete row/column support
* [x] Column resize support
* [ ] Compare mobile support to standard prose mobile support and ensure it aligns
* [x] Bug: Unsaved changes don't show up as 'dirty' when you return to the file
* [x] Add ability to switch to plain file editor
* [x] Get travis to pass
* [x] Add unit tests

I welcome your thoughts and feedback!

EDIT: Looks like legacy node builds in travis are failing because handsontable is installed via github (`Unsupported URL Type: github:handsontable/handsontable`). I'm sure there's an easy fix.