### PR TITLE
Only insert 1 line break after frontmatter

### DIFF
--- a/app/models/file.js
+++ b/app/models/file.js
@@ -155,7 +155,7 @@ module.exports = Backbone.Model.extend({
         throw err;
       }
 
-      return ['---', frontmatter, '---'].join('\n') + '\n\n' + content;
+      return ['---', frontmatter, '---'].join('\n') + '\n' + content;
     } else {
       return content;
     }


### PR DESCRIPTION
Fixes #916 - unless there was some other reason to insert 2 lines? If so, we can probably just trim a leading `\n` off `content`.