### PR TITLE
Improve npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "vinyl-source-stream": "^0.1.1"
   },
   "scripts": {
-    "test": "node_modules/.bin/gulp && node_modules/.bin/mocha-phantomjs test/index.html",
-    "start": "serve"
+    "test": "gulp && mocha-phantomjs test/index.html",
+    "start": "gulp watch & serve"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
With this pull request, running `npm start` executes `gulp watch` and `serve` at the same time, so one command to start developing.

It also simplifies the script for `npm test` - [npm scripts](https://docs.npmjs.com/cli/run-script) put any binaries installed by dependencies in the `PATH` when the npm script is run, so it's not necessary to put the full path in there. They'll work even if they're not installed globally.