### PR TITLE
Use full width on metadata editor

### DIFF
--- a/style.css
+++ b/style.css
@@ -1749,7 +1749,6 @@ ins {
 
   .post .view.meta {
     background:#f0f0f0;
-    width:360px;
     margin:0 auto;
     }
 


### PR DESCRIPTION
I've wondered why the metadata editor is so narrow, as it cuts off longer text. This could be resolved with some CSS (though it would need to be CodeMirror-specific) but I thought perhaps a full-width metadata container would be a good idea as well. Thoughts?

Before:
![screen shot 2016-03-07 at 06 50 48](https://cloud.githubusercontent.com/assets/761444/13568965/1ce1ac60-e433-11e5-8675-76c93468abca.png)

After:
![screen shot 2016-03-07 at 06 57 26](https://cloud.githubusercontent.com/assets/761444/13568966/21938e86-e433-11e5-8712-5afbe0d2ef92.png)
