### PR TITLE
Fix/session storage

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -1385,6 +1385,9 @@ module.exports = Backbone.View.extend({
     // Unbind beforeunload prompt
     window.onbeforeunload = null;
 
+    // So we don't endlessly stash when choosing new files
+    $(window).off('pagehide', this.stashFile);
+
     // Reset dirty models on navigation
     if (this.dirty) {
       this.stashFile();

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -1261,8 +1261,9 @@ module.exports = Backbone.View.extend({
         var path = model.get('path');
         this.path = path;
 
-        // Unset dirty, return to edit view
+        // Unset dirty, remove session storage, return to edit view
         this.dirty = false;
+        this.clearStashForPath(this.absoluteFilepath());
         this.edit();
 
         var old = model.get('oldpath');

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -66,7 +66,7 @@ module.exports = Backbone.View.extend({
     this.listenTo(this.sidebar, 'translate', this.translate);
 
     // Stash editor and metadataEditor content to sessionStorage on pagehide event
-    this.listenTo($(window), 'pagehide', this.stashFile);
+    $(window).on('pagehide', this.stashFile);
 
     // Prevent exit when there are unsaved changes
     // jQuery won't bind to 'beforeunload' event
@@ -1168,7 +1168,7 @@ module.exports = Backbone.View.extend({
 
   stashFile: function(e) {
     if (e) e.preventDefault();
-    if (!window.sessionStorage) return false;
+    if (!window.sessionStorage || !this.dirty) return false;
 
     var store = window.sessionStorage;
     var filepath = this.absoluteFilepath();

--- a/test/mocks/views/header.js
+++ b/test/mocks/views/header.js
@@ -1,0 +1,18 @@
+var HeaderView = require('../../../app/views/header'),
+  distate = require('../helpers').distate,
+  mockFile = require('../models/file'),
+  mockRepo = require('../models/repo');
+
+module.exports = distate.register(header);
+
+function header() {
+  return new HeaderView({
+    user: {},
+    repo: mockRepo(),
+    file: mockFile,
+    input: '',
+    title: 'title',
+    placeholder: '',
+    alterable: true
+  });
+}

--- a/test/spec/views/file.js
+++ b/test/spec/views/file.js
@@ -6,8 +6,8 @@ var mockRepo = require('../../mocks/models/repo');
 var mockFile = require('../../mocks/models/file');
 var mockApp = require('../../mocks/views/app');
 var mockRouter = require('../../mocks/router');
+var mockHeader = require('../../mocks/views/header');
 var Handsontable = require('handsontable');
-
 
 describe('File view', function() {
   var fileView;
@@ -143,14 +143,25 @@ describe('File view', function() {
         }, 400);
       });
     });
-
   });
 
   describe('in preview mode', function() {
-      it('escapes script tags when compiling preview', function() {
-          var content = "<script>alert('pwned')</script>";
-          expect(fileView.compilePreview(content)).to.equal('&lt;script&gt;alert(&#x27;pwned&#x27;)&lt;&#x2F;script&gt;');
-      });
+    it('escapes script tags when compiling preview', function() {
+      var content = "<script>alert('pwned')</script>";
+      expect(fileView.compilePreview(content)).to.equal('&lt;script&gt;alert(&#x27;pwned&#x27;)&lt;&#x2F;script&gt;');
+    });
+  });
+
+  describe('session storage', function () {
+    it('does not stash to session storage when not dirty', function () {
+      fileView.dirty = false;
+      fileView.header = mockHeader();
+      fileView.header.inputGet = function () { return 'path'; };
+      fileView.stashFile();
+      var key = fileView.absoluteFilepath();
+      var store = window.sessionStorage;
+      expect(store.getItem(key)).not.ok;
+    });
   });
 
 });


### PR DESCRIPTION
Fix #913, which was correctly identified as attaching a Backbone event listener to a non-Backbone object h/t @timwis.

Also enables better session storage when you navigate away without saving, which was broken before on the faulty event listener. 