### PR TITLE
Remove unwanted metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ oauth.json
 test/lib
 _site
 site
+npm-debug.log

--- a/app/views/meta/textarea.js
+++ b/app/views/meta/textarea.js
@@ -70,7 +70,8 @@ module.exports = Backbone.View.extend({
 
   getValue: function() {
     try {
-      return jsyaml.safeLoad(this.codeMirror.getValue()) || '';
+      var value = jsyaml.safeLoad(this.codeMirror.getValue());
+      return (value || value === 0) ? value : '';
     }
     catch(err) {
       console.log('Error parsing yaml front matter for ', this.name);

--- a/app/views/meta/textarea.js
+++ b/app/views/meta/textarea.js
@@ -70,7 +70,7 @@ module.exports = Backbone.View.extend({
 
   getValue: function() {
     try {
-      return jsyaml.safeLoad(this.codeMirror.getValue());
+      return jsyaml.safeLoad(this.codeMirror.getValue()) || '';
     }
     catch(err) {
       console.log('Error parsing yaml front matter for ', this.name);

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -284,9 +284,14 @@ module.exports = Backbone.View.extend({
       }
     }
 
-    // TODO Currently, it's not possible to delete metadata.
-    // There should be some logic here that looks to see if there's any metadata
-    // that isn't an element, isn't hidden, and isn't in the raw editor.
+    // Remove metadata elements where values are empty strings,
+    // unless they are the title, or are hidden.
+    for (var key in metadata) {
+      if (key !== 'title' && metadata[key] === '') {
+        delete metadata[key];
+      }
+    }
+
     return metadata;
   },
 

--- a/test/spec/views/meta-forms.js
+++ b/test/spec/views/meta-forms.js
@@ -34,6 +34,16 @@ describe('Metadata form elements', function() {
   });
 
   describe('Reading values', function() {
+    it('returns empty strings for null', function () {
+      [TextForm, TextArea, Select, Multiselect].forEach(function (View) {
+        var view = new View({data: {
+          field: {}
+        }});
+        view.render();
+        expect(view.getValue()).to.equal('');
+      });
+    });
+
     it('reads values from a text element', function() {
       data.type = 'text';
       var text = new TextForm({data: data});

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -221,7 +221,18 @@ describe('Metadata editor view', function() {
       }]);
       metadataEditor.render();
       var values = metadataEditor.getValue();
-      expect(values.hasOwnProperty('layout')).to.notOk;
+      expect(values.hasOwnProperty('layout')).not.ok;
+    });
+
+    it('does not remove title and published meta properties, even if they are unset', function () {
+      model.set('metadata', {
+        title: '',
+        published: ''
+      });
+      metadataEditor.render();
+      var values = metadataEditor.getValue();
+      expect(values.hasOwnProperty('title')).ok;
+      expect(values.hasOwnProperty('published')).ok;
     });
 
     it('textarea names do not collide with view methods', function() {

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -221,8 +221,7 @@ describe('Metadata editor view', function() {
       }]);
       metadataEditor.render();
       var values = metadataEditor.getValue();
-      expect(values.hasOwnProperty('layout')).to.ok;
-      expect(metadataEditor.model.get('metadata').layout).to.equal('');
+      expect(values.hasOwnProperty('layout')).to.notOk;
     });
 
     it('textarea names do not collide with view methods', function() {
@@ -528,6 +527,84 @@ describe('Metadata editor view', function() {
       metadataEditor.render();
       expect($('#meta').find('select').find('option').length).to.equal(2);
       expect(model.get('metadata').multiselect).to.deep.equal(['foo', 'bar']);
+    });
+
+    it('removes meta values that are empty strings from text fields', function () {
+      model.set('defaults', [{
+        name: 'false',
+        field: {
+          element: 'text',
+          value: 'false'
+        }
+      }, {
+        name: 'null',
+        field: {
+          element: 'text',
+          value: 'null'
+        }
+      }, {
+        name: 'numerical zero',
+        field: {
+          element: 'text',
+          value: 0
+        }
+      }, {
+        name: 'empty string',
+        field: {
+          element: 'text',
+          value: ''
+        }
+      }]);
+      metadataEditor.render();
+      expect(model.get('metadata').hasOwnProperty('false')).ok;
+      expect(model.get('metadata').hasOwnProperty('null')).ok;
+      expect(model.get('metadata').hasOwnProperty('numerical zero')).ok;
+      expect(model.get('metadata').hasOwnProperty('empty string')).not.ok;
+    });
+
+    it('removes meta values that are empty strings from textarea fields', function () {
+      model.set('defaults', [{
+        name: 'false',
+        field: {
+          element: 'textarea',
+          value: 'false'
+        }
+      }, {
+        name: 'null',
+        field: {
+          element: 'textarea',
+          value: 'null'
+        }
+      }, {
+        name: 'numerical zero',
+        field: {
+          element: 'textarea',
+          value: 0
+        }
+      }, {
+        name: 'empty string',
+        field: {
+          element: 'textarea',
+          value: ''
+        }
+      }]);
+      metadataEditor.render();
+      // textareas behave differently, parsing is done by codemirror
+      // and jsyaml, so we have less control over the outcome.
+      expect(model.get('metadata').hasOwnProperty('false')).not.ok;
+      expect(model.get('metadata').hasOwnProperty('null')).not.ok;
+      expect(model.get('metadata').hasOwnProperty('numerical zero')).ok;
+      expect(model.get('metadata').hasOwnProperty('empty string')).not.ok;
+    });
+
+    it('removes empty string values that are not defaults', function () {
+      model.set('metadata', {
+        notExist: '',
+        shouldExist: false
+      });
+      metadataEditor.render();
+      expect(model.get('metadata').hasOwnProperty('shouldExist')).ok;
+      expect(model.get('metadata').hasOwnProperty('notExist')).not.ok;
     });
   });
 });


### PR DESCRIPTION
1. If a metadata form value is not set, and there is no default value, meta forms should* return an empty string `""`.
2. Instead of including the empty string meta value in frontmatter, Prose will now just not include that property.
3. Exceptions are `title` and `published`.

*Textareas forms are another exception, since reading the values are abstracted in CodeMirror and js-yaml code, `"null"` and `"false"` both register as empty strings and thus will not be included. If for some reason you need to set a meta form to `"false"` or `false`, use a text form.

Would close #945 