### PR TITLE
CSV editor should mark file 'dirty' when col or row is created/removed

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -345,7 +345,11 @@ module.exports = Backbone.View.extend({
       undo: true,
       afterChange: function(changes, source) {
         if (source !== 'loadData') self.makeDirty();
-      }
+      },
+      afterRemoveCol: this.makeDirty,
+      afterRemoveRow: this.makeDirty,
+      afterCreateCol: this.makeDirty,
+      afterCreateRow: this.makeDirty
     })
 
     this.editor.getValue = function() {


### PR DESCRIPTION
Fixes #959

Note that there is one case where it doesn't recognize the change, which I believe is an issue with Handsontable and have [reported to them](https://github.com/handsontable/handsontable/issues/3465).