### PR TITLE
Resolves colon bug on textareas

### DIFF
--- a/app/views/meta/textarea.js
+++ b/app/views/meta/textarea.js
@@ -70,8 +70,8 @@ module.exports = Backbone.View.extend({
 
   getValue: function() {
     try {
-      var value = jsyaml.safeLoad(this.codeMirror.getValue());
-      return (value || value === 0) ? value : '';
+      var value = jsyaml.safeLoad(this.codeMirror.getValue().replace(':', '&58;'));
+      return (value || value === 0) ? value.replace('&58;', ':') : '';
     }
     catch(err) {
       console.log('Error parsing yaml front matter for ', this.name);
@@ -83,7 +83,7 @@ module.exports = Backbone.View.extend({
   setValue: function(value) {
     // Only set value if not null or undefined.
     if (value != undefined) {
-      this.codeMirror.setValue(value);
+      this.codeMirror.setValue(value.replace('&58;', ':'));
     }
   }
 });


### PR DESCRIPTION
This PR causes two tests to fail, and I'm not totally sure why. 

```
  1) Metadata editor view setting defaults on load removes meta values that are empty strings from textarea fields:
     AssertionError: expected true to be falsy
 2) Metadata form elements Reading values does not endlessly escape text areas:

      AssertionError: expected '' to equal '<script>alert("hi");</script>'
      + expected - actual

      +<script>alert("hi");</script>
```

attn @dereklieu 