### PR TITLE
New jsyaml wraps quotes in single quotes

### DIFF
--- a/test/spec/vendor/js-yaml.js
+++ b/test/spec/vendor/js-yaml.js
@@ -8,7 +8,7 @@ describe('Js-yaml coverage', function () {
     expect(loaded.noquotes).not.ok;
 
     var dumped = yaml.safeDump(loaded);
-    expect(/quotes: "false"/.test(dumped)).ok;
+    expect(/quotes: 'false'/.test(dumped)).ok;
     expect(/noquotes: false/.test(dumped)).ok;
   });
 });


### PR DESCRIPTION
Should fix the failing test.