### PR TITLE
Save initial scope cookie if public and private

### DIFF
--- a/app/views/start.js
+++ b/app/views/start.js
@@ -11,6 +11,10 @@ auth.scope = cookie.get('scope') || 'repo';
 module.exports = Backbone.View.extend({
   id: 'start',
 
+  initialize: function () {
+    this.persistScope(auth.scope);
+  },
+
   events: {
     'click a[href="#scopes"]': 'toggleScope',
     'change .toggle-hide select': 'setScope'
@@ -29,11 +33,15 @@ module.exports = Backbone.View.extend({
   },
 
   setScope: function(e) {
-    var scope = $(e.currentTarget).val(),
-        expire = new Date((new Date()).setYear((new Date()).getFullYear() + 20));
-    auth.scope = scope;
-    cookie.set('scope', scope, expire);
+    var scope = $(e.currentTarget).val();
+    this.persistScope(scope);
     this.render();
     router.app.nav.render();
+  },
+
+  persistScope: function(scope) {
+    var expire = new Date((new Date()).setYear((new Date()).getFullYear() + 20));
+    auth.scope = scope;
+    cookie.set('scope', scope, expire);
   }
 });


### PR DESCRIPTION
If a `scope` cookie didn't exist when you authenticated, and you didn't touch the dropdown toggle for public & private/public only, then the app doesn't set a `scope` cookie because `setScope` fires on change events. This should fix that by setting the cookie on init.