### PR TITLE
Diff on lines, rather than words

### DIFF
--- a/app/views/file.js
+++ b/app/views/file.js
@@ -928,7 +928,7 @@ module.exports = Backbone.View.extend({
     var text1 = this.model.isNew() ? '' : _.escape(this.model.get('previous'));
     var text2 = _.escape(this.model.serialize());
 
-    var d = diff.diffWords(text1, text2);
+    var d = diff.diffLines(text1, text2);
     var length = d.length;
     var compare = '';
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "chrono": "~1.0.4",
     "codemirror": "^5.13.2",
     "deepmerge": "~0.2.7",
-    "diff": "~1.0.4",
+    "diff": "~2.2.0",
     "handsontable": "git://github.com/handsontable/handsontable.git#0.20.2",
     "ignore": "~2.2.7",
     "jquery-browserify": "~1.8.1",


### PR DESCRIPTION
Close #1023 

Speeds up diffs on larger files. Previously, Prose would freeze for a few seconds each time you tried to save a moderately large file (~1,500 LOC) as it churned through diffs word-by-word. 