### PR TITLE
Implement CURRENT_USER variable in config

### DIFF
--- a/app/util.js
+++ b/app/util.js
@@ -296,19 +296,5 @@ module.exports = {
     } catch (err) {
         return t('notification.error.github');
     }
-  },
-
-  replaceVariables: function(variables, setting) {
-    var result = setting;
-    if (result) {
-      for (var name in variables) {
-        if (variables.hasOwnProperty(name)) {
-          var value = variables[name];
-          result = result.replace(name, value);
-        }
-      }
-    }
-    return result;
   }
-
 };

--- a/app/util.js
+++ b/app/util.js
@@ -296,5 +296,19 @@ module.exports = {
     } catch (err) {
         return t('notification.error.github');
     }
+  },
+
+  replaceVariables: function(variables, setting) {
+    var result = setting;
+    if (result) {
+      for (var name in variables) {
+        if (variables.hasOwnProperty(name)) {
+          var value = variables[name];
+          result = result.replace(name, value);
+        }
+      }
+    }
+    return result;
   }
+
 };

--- a/test/fixtures/metadata.js
+++ b/test/fixtures/metadata.js
@@ -4,7 +4,8 @@ module.exports.string = jsyaml.safeDump({
   prose: {
     metadata: {
       _posts: [
-        'date: CURRENT_DATETIME'
+        'date: CURRENT_DATETIME',
+        'author: CURRENT_USER'
       ]
     },
     proseProp: true
@@ -14,6 +15,9 @@ module.exports.string = jsyaml.safeDump({
 
 module.exports.forms = jsyaml.safeDump({
   prose: {
+    rooturl: 'root/CURRENT_USER/folder',
+    media: 'media/CURRENT_USER/folder',
+    siteurl: 'site/CURRENT_USER/folder',
     metadata: {
       _posts: [{
         name: 'date',
@@ -21,7 +25,17 @@ module.exports.forms = jsyaml.safeDump({
           element: 'textarea',
           value: 'CURRENT_DATETIME'
         }
+      }, {
+        name: 'author',
+        field: {
+          element: 'textarea',
+          value: 'CURRENT_USER'
+        }
       }]
-    }
+    },
+    users: [{
+      login: 'github1',
+      user: 'usr1'
+    }]
   }
 });

--- a/test/spec/collections/files.js
+++ b/test/spec/collections/files.js
@@ -4,6 +4,7 @@ var fileCollectionMocker = require('../../mocks/collections/files');
 var fileMocker = require('../../mocks/models/file');
 var stringMeta = require('../../fixtures/metadata.js').string;
 var formMeta = require('../../fixtures/metadata.js').forms;
+var cookie = require('../../../app/cookie');
 
 describe('files collection', function() {
 
@@ -30,6 +31,34 @@ describe('files collection', function() {
       success: function() {
         var date = new Date(files.defaults._posts[0].field.value);
         expect(_.isDate(date)).to.eql(true);
+        done();
+      }
+    });
+  });
+
+  it('Honors CURRENT_USER var with mapped user when metadata is a form element', function(done) {
+    cookie.set('login', 'github1');
+    var files = fileCollectionMocker();
+    files.parseConfig(fileMocker(formMeta), {
+      success: function() {
+        expect(files.config.rooturl).to.eql('root/usr1/folder');
+        expect(files.config.media).to.eql('media/usr1/folder');
+        expect(files.config.siteurl).to.eql('site/usr1/folder');
+        expect(files.defaults._posts[1].field.value).to.eql('usr1');
+        done();
+      }
+    });
+  });
+
+  it('Honors CURRENT_USER var with unmapped user when metadata is a form element', function(done) {
+    cookie.set('login', 'github2');
+    var files = fileCollectionMocker();
+    files.parseConfig(fileMocker(formMeta), {
+      success: function() {
+        expect(files.config.rooturl).to.eql('root/github2/folder');
+        expect(files.config.media).to.eql('media/github2/folder');
+        expect(files.config.siteurl).to.eql('site/github2/folder');
+        expect(files.defaults._posts[1].field.value).to.eql('github2');
         done();
       }
     });


### PR DESCRIPTION
Close #557 

Support for automatically inserting the current userid into configuration.

For example, an automatic `author` variable:

    prose:
      metadata:
        "_posts":
          - name: "author"
            field: "CURRENT_USER"

Or else allow for breaking up the _posts folder by user id:

    prose:
      rooturl: CURRENT_USER/_posts
      media: CURRENT_USER/assets

In case the github login is not what you want, you can also map users. e.g. if I want my personal rooturl to be `alee/_posts`:

    prose:
      rooturl: CURRENT_USER/_posts
      users:
        - login: "DevAndyLee"
          user: "alee"

This makes for a nicely personalised experience, especially useful for less-technical authors.