### PR TITLE
Implement metadata image selection

### DIFF
--- a/app/util.js
+++ b/app/util.js
@@ -272,42 +272,6 @@ module.exports = {
     return false;
   },
 
-  renderMedia: function(data, elem, controller, back) {
-    var util = this;
-    var tmpl = _(templates.dialogs.mediadirectory).template();
-
-    if (back && (back.join() !== this.assetsDirectory)) {
-      var link = back.slice(0, back.length - 1).join('/');
-      elem.append('<li class="directory back"><a href="' + link + '"><span class="ico fl small inline back"></span>Back</a></li>');
-    }
-
-    data.each(function(d) {
-      var parts = d.get('path').split('/');
-      var path = parts.slice(0, parts.length - 1).join('/');
-
-      elem.append(tmpl({
-        name: d.get('name'),
-        type: d.get('type'),
-        path: path + '/' + encodeURIComponent(d.get('name')),
-        isMedia: util.isMedia(d.get('name').split('.').pop())
-      }));
-    });
-
-    $('.asset a', elem).on('click', function(e) {
-      var href = $(this).attr('href');
-      var alt = util.trim($(this).text());
-
-      if (util.isImage(href.split('.').pop())) {
-        elem.closest('div.dialog.media').find('input[name="url"]').val(href);
-        elem.closest('div.dialog.media').find('input[name="alt"]').val(alt);
-      } else {
-        controller.view.editor.replaceSelection(href);
-        controller.view.editor.focus();
-      }
-      return false;
-    });
-  },
-
   parseLinkHeader: function(xhr, options) {
     options = _.clone(options) || {};
 

--- a/app/util.js
+++ b/app/util.js
@@ -30,6 +30,21 @@ module.exports = {
     return [matches[1], matches[2]];
   },
 
+  extractMedia: function(config, collection) {
+    var self = this;
+    // Fetch the media directory to display its contents
+    var mediaDirectoryPath = config.media;
+    var match = new RegExp('^' + mediaDirectoryPath);
+
+    var media = collection.filter(function(m) {
+      var path = m.get('path');
+
+      return m.get('type') === 'file' && match.test(path) &&
+        (self.isBinary(path) || self.isImage(m.get('extension')));
+    });
+    return [media, mediaDirectoryPath];
+  },
+
   validPathname: function(path) {
     var regex = /^([a-zA-Z0-9_\-]|\.)+$/;
     return _.all(path.split('/'), function(filename) {

--- a/app/util.js
+++ b/app/util.js
@@ -257,6 +257,42 @@ module.exports = {
     return false;
   },
 
+  renderMedia: function(data, elem, controller, back) {
+    var util = this;
+    var tmpl = _(templates.dialogs.mediadirectory).template();
+
+    if (back && (back.join() !== this.assetsDirectory)) {
+      var link = back.slice(0, back.length - 1).join('/');
+      elem.append('<li class="directory back"><a href="' + link + '"><span class="ico fl small inline back"></span>Back</a></li>');
+    }
+
+    data.each(function(d) {
+      var parts = d.get('path').split('/');
+      var path = parts.slice(0, parts.length - 1).join('/');
+
+      elem.append(tmpl({
+        name: d.get('name'),
+        type: d.get('type'),
+        path: path + '/' + encodeURIComponent(d.get('name')),
+        isMedia: util.isMedia(d.get('name').split('.').pop())
+      }));
+    });
+
+    $('.asset a', elem).on('click', function(e) {
+      var href = $(this).attr('href');
+      var alt = util.trim($(this).text());
+
+      if (util.isImage(href.split('.').pop())) {
+        elem.closest('div.dialog.media').find('input[name="url"]').val(href);
+        elem.closest('div.dialog.media').find('input[name="alt"]').val(alt);
+      } else {
+        controller.view.editor.replaceSelection(href);
+        controller.view.editor.focus();
+      }
+      return false;
+    });
+  },
+
   parseLinkHeader: function(xhr, options) {
     options = _.clone(options) || {};
 

--- a/app/views/assetselection.js
+++ b/app/views/assetselection.js
@@ -1,0 +1,91 @@
+var $ = require('jquery-browserify');
+var Backbone = require('backbone');
+var _ = require('underscore');
+var upload = require('../upload');
+var templates = require('../../dist/templates');
+var util = require('../util');
+
+module.exports = Backbone.View.extend({
+  template: templates.dialogs.media,
+
+  events: {
+    'change .upload': 'fileInput',
+  },
+
+  initialize: function(options) {
+    this.assets = options.assets;
+    this.ancestor = options.ancestor;
+    this.model = options.model;
+    this.includeAltText = options.includeAltText;
+    this.onInsert = options.onInsert;
+    this.render();
+  },
+
+  render: function() {
+    $(this.el).html($(_.template(this.template, {
+      description: t('dialogs.media.description', {
+        input: '<input class="upload" type="file" />'
+      }),
+      includeMediaDirectory: this.assets && this.assets.length,
+      isWritable: this.model.get('writable'),
+      includeAltText: this.includeAltText
+    })));
+    var self = this;
+
+    // Construct the media assets list
+    if (this.assets && this.assets.length) {
+      var $media = this.$el.find('.mediaDirectory');
+      var tmpl = _(templates.dialogs.mediadirectory).template();
+      this.assets.each(function(asset) {
+        var parts = asset.get('path').split('/');
+        var path = parts.slice(0, parts.length - 1).join('/');
+
+        $media.append(tmpl({
+          name: asset.get('name'),
+          type: asset.get('type'),
+          path: path + '/' + encodeURIComponent(asset.get('name')),
+          isMedia: util.isMedia(asset.get('name').split('.').pop())
+        }));
+      });
+
+      $('.asset a', $media).on('click', function(e) {
+        var href = $(this).attr('href');
+        var alt = util.trim($(this).text());
+        $(self.el).find('input[name="url"]').val(href);
+        $(self.el).find('input[name="alt"]').val(alt);
+        return false;
+      });
+    }
+
+    $(this.el).find(".insert").click(this.onInsert);
+    return this.$el;
+  },
+
+  fileInput: function(e) {
+    var $dialog = $(e.target).closest('div.dialog.media');
+    var self = this;
+    upload.fileSelect(e, function(e, file, content) {
+      self.updateImageInsert(e, file, content, self.ancestor, $dialog);
+    });
+
+    return false;
+  },
+
+  updateImageInsert: function(e, file, content, target, $dialog) {
+    var path = (this.assets) ?
+                    this.assets :
+                    util.extractFilename(this.model.attributes.path)[0];
+
+    var src = path + '/' + encodeURIComponent(file.name);
+    $dialog.find('input[name="url"]').val(src);
+    $dialog.find('input[name="alt"]').val('');
+
+    target.queue = {
+      e: e,
+      file: file,
+      content: content
+    };
+    return false;
+  },
+
+});

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -386,16 +386,17 @@ module.exports = Backbone.View.extend({
     // Bind Drag and Drop work on the editor
     if (this.model.get('markdown') && this.model.get('writable')) {
       upload.dragDrop(this.$el, (function(e, file, content) {
-        var $dialog = this.$el.find('div[data-element="dialog"]');
+        var $dialog = this.$el.find('#toolbar-dialog');
         if ($dialog.hasClass('dialog')) {
-          this.updateImageInsert(e, file, content, this.toolbar, dialog);
+          this.toolbar.updateImageInsert(e, file, content, this.toolbar, $dialog);
         } else {
           // Clear selection
           this.editor.focus();
           this.editor.replaceSelection('');
 
           // Append images links in this.upload()
-          this.upload(e, file, content);
+          var callback = this.toolbar.uploadInsert.bind(this.toolbar);
+          this.upload(e, file, content, undefined, callback);
         }
       }).bind(this));
     }
@@ -455,7 +456,7 @@ module.exports = Backbone.View.extend({
 
     // If a dialog window is open and the editor is in focus, close it.
     this.$el.find('.toolbar .group a').removeClass('on');
-    this.$el.find('div[data-element="dialog"]').empty().removeClass();
+    this.$el.find('#toolbar-dialog').empty().removeClass();
   },
 
   initToolbar: function() {
@@ -469,7 +470,6 @@ module.exports = Backbone.View.extend({
     this.subviews['toolbar'] = this.toolbar;
     this.toolbar.setElement(this.$el.find('#toolbar')).render();
 
-    this.listenTo(this.toolbar, 'updateImageInsert', this.updateImageInsert);
     this.listenTo(this.toolbar, 'post', this.post);
   },
 
@@ -555,16 +555,22 @@ module.exports = Backbone.View.extend({
   },
 
   renderMetadata: function() {
+    var media = [];
+    if (this.config.media) {
+        // Fetch the media directory to display its contents
+        var returned = util.extractMedia(this.config, this.collection);
+        media = returned[0];
+    }
+
     this.metadataEditor = new MetadataView({
+      view: this,
       model: this.model,
       titleAsHeading: this.titleAsHeading(),
-      view: this
+      media: media
     });
 
     this.metadataEditor.setElement(this.$el.find('#meta')).render();
     this.subviews['metadata'] = this.metadataEditor;
-
-    this.listenTo(this.metadataEditor, 'updateImageInsert', this.updateImageInsert);
   },
 
   render: function() {
@@ -1335,22 +1341,6 @@ module.exports = Backbone.View.extend({
     if (this.nav) this.nav.updateState(label, classes, kill);
   },
 
-  updateImageInsert: function(e, file, content, target, $dialog) {
-    var path = (this.config.media) ?
-                    this.config.media :
-                    util.extractFilename(this.model.attributes.path)[0];
-
-    var src = path + '/' + encodeURIComponent(file.name);
-    $dialog.find('input[name="url"]').val(src);
-    $dialog.find('input[name="alt"]').val('');
-
-    target.queue = {
-      e: e,
-      file: file,
-      content: content
-    };
-  },
-
   defaultUploadPath: function(fileName) {
     // Default to media directory if defined in config,
     // current directory if no path specified
@@ -1360,14 +1350,17 @@ module.exports = Backbone.View.extend({
     return _.compact([dir, fileName]).join('/');
   },
 
-  upload: function(e, file, content, path, successCb, failureCb) {
+  upload: function(e, file, content, path, successCb) {
     // Loading State
     this.updateSaveState(t('actions.upload.uploading', { file: file.name }), 'saving');
 
     var uploadPath = path || this.defaultUploadPath(file.name);
     this.collection.upload(file, content, uploadPath, {
       success: (successCb).bind(this),
-      error: (failureCb).bind(this)
+      error: (function(model, xhr, options) {
+        var message = util.xhrErrorMessage(xhr);
+        this.updateSaveState(message, 'error');
+      }).bind(this)
     });
   },
 

--- a/app/views/meta/image.js
+++ b/app/views/meta/image.js
@@ -1,0 +1,43 @@
+var $ = require('jquery-browserify');
+var Backbone = require('backbone');
+var _ = require('underscore');
+var upload = require('../../upload');
+var templates = require('../../../dist/templates');
+var util = require('../../util');
+
+module.exports = Backbone.View.extend({
+
+  template: templates.meta.image,
+  type: 'image',
+
+  initialize: function(options) {
+    this.name = options.data.name;
+  },
+
+  // TODO write tests for upload behavior.
+  // TODO write tests for url behavior.
+  render: function () {
+    var data = this.options.data;
+    var image = {
+      name: data.name,
+      label: data.field.label,
+      help: data.field.help,
+      value: data.field.value,
+      placeholder: data.field.placeholder,
+    };
+
+    this.setElement($(_.template(this.template, image, {
+      variable: 'meta'
+    })));
+    this.$form = this.$el.find('input');
+    return this.$el;
+  },
+
+  getValue: function() {
+    return this.$form.val();
+  },
+
+  setValue: function(value) {
+    this.$form.val(value);
+  }
+});

--- a/style/_main.scss
+++ b/style/_main.scss
@@ -1474,10 +1474,10 @@
       margin:5px 0 0;
       width:90%;
       }
-      .meta .create input {
+      .meta .create > input {
         padding-right:135px;
         }
-      .meta .create .button {
+      .meta .create > .button {
         position:absolute;
         top:2px;
         right:0;

--- a/style/_main.scss
+++ b/style/_main.scss
@@ -972,7 +972,6 @@
   background:#fff;
   position:absolute;
   z-index: 100;
-  top:100%;
   width:100%;
   margin:0 auto;
   border:1px solid #a8afb2;

--- a/style/_type.scss
+++ b/style/_type.scss
@@ -183,7 +183,8 @@ input[type=text] {
           border-radius:2px;
   }
 textarea,
-input[type=text] {
+input[type=text],
+.dialog input[type=text] {
   background-color:#fff;
   vertical-align:middle;
   max-width:100%;
@@ -196,6 +197,10 @@ input[type=text] {
      -moz-transition:border linear 150ms;
        -o-transition:border linear 150ms;
           transition:border linear 150ms;
+  }
+
+input[readonly] {
+  background-color: #e4e4e4;
   }
 
 textarea#code {

--- a/templates/dialogs/media.html
+++ b/templates/dialogs/media.html
@@ -1,9 +1,9 @@
 <div class='inner clearfix'>
 
-  <div <% if (assetsDirectory) { %>class='col fl'<% } %>>
+  <div <% if (includeMediaDirectory) { %>class='col fl'<% } %>>
     <label><%= t('dialogs.media.title') %></label>
 
-    <% if (writable) { %>
+    <% if (isWritable) { %>
       <div class='contain clearfix'>
         <span class='ico picture-add fl'></span>
         <%= description %>
@@ -11,19 +11,19 @@
     <% } %>
 
     <input type='text' name='url' placeholder="<%= t('dialogs.media.hrefPlaceholder')%>" />
-    <% if (altText) { %>
+    <% if (includeAltText) { %>
       <input type='text' name='alt' placeholder="<%= t('dialogs.media.altPlaceholder')%>" />
     <% } %>
     <a href='#' class='button round insert' data-type='media'><%= t('dialogs.link.insert') %></a>
-      <% if (!assetsDirectory) { %>
+      <% if (!includeMediaDirectory) { %>
         <small class='caption deemphasize'><%= t('dialogs.media.help') %></small>
       <% } %>
   </div>
 
-  <% if (assetsDirectory) { %>
+  <% if (includeMediaDirectory) { %>
     <div class='col col-last fl media-listing'>
       <label><%= t('dialogs.media.choose') %></label>
-      <ul data-element='media'></ul>
+      <ul class='mediaDirectory'></ul>
       <small class='caption deemphasize'><%= t('dialogs.media.helpMedia') %></small>
     </div>
   <% } %>

--- a/templates/dialogs/media.html
+++ b/templates/dialogs/media.html
@@ -11,7 +11,9 @@
     <% } %>
 
     <input type='text' name='url' placeholder="<%= t('dialogs.media.hrefPlaceholder')%>" />
-    <input type='text' name='alt' placeholder="<%= t('dialogs.media.altPlaceholder')%>" />
+    <% if (altText) { %>
+      <input type='text' name='alt' placeholder="<%= t('dialogs.media.altPlaceholder')%>" />
+    <% } %>
     <a href='#' class='button round insert' data-type='media'><%= t('dialogs.link.insert') %></a>
       <% if (!assetsDirectory) { %>
         <small class='caption deemphasize'><%= t('dialogs.media.help') %></small>
@@ -21,7 +23,7 @@
   <% if (assetsDirectory) { %>
     <div class='col col-last fl media-listing'>
       <label><%= t('dialogs.media.choose') %></label>
-      <ul id='media'></ul>
+      <ul data-element='media'></ul>
       <small class='caption deemphasize'><%= t('dialogs.media.helpMedia') %></small>
     </div>
   <% } %>

--- a/templates/meta/image.html
+++ b/templates/meta/image.html
@@ -7,4 +7,5 @@
       <input class='metafield inline' type='text' name='<%= meta.name %>' value='<%= meta.value %>' data-type='<%= meta.type %>' placeholder='<%= meta.placeholder %>' readonly/>
     </div>
   </fieldset>
+  <div></div>
 </div>

--- a/templates/meta/image.html
+++ b/templates/meta/image.html
@@ -1,0 +1,10 @@
+<div class='form-item'>
+  <label for='<%= meta.name %>'><%= meta.label %></label>
+  <% if (meta.help) { %><small class='deemphasize'><%= meta.help %></small><% } %>
+  <fieldset>
+    <div class='create'>
+      <a href='#' class='round select-image inline button' data-select='<%= meta.name %>' title="<%= t('toolbar.image') %>"><%= t('toolbar.image') %></a>
+      <input class='metafield inline' type='text' name='<%= meta.name %>' value='<%= meta.value %>' data-type='<%= meta.type %>' placeholder='<%= meta.placeholder %>' readonly/>
+    </div>
+  </fieldset>
+</div>

--- a/templates/toolbar.html
+++ b/templates/toolbar.html
@@ -67,4 +67,4 @@
   </ul>
 </div>
 <% } %>
-<div id='dialog'></div>
+<div data-element='dialog'></div>

--- a/templates/toolbar.html
+++ b/templates/toolbar.html
@@ -67,4 +67,4 @@
   </ul>
 </div>
 <% } %>
-<div data-element='dialog'></div>
+<div id="toolbar-dialog"></div>


### PR DESCRIPTION
@dereklieu: Implements issue #998 without using an external service. #998 is an important issue for me and I cannot use prose without this feature.

Usage: 

```
prose:
  metadata:
    _posts:
      - name: "image"
        field:
          element: "image"
          placeholder: "default-image.jpg"
          label: "My Image"
```

Possible extension functionality:

Add a _prose.yml config value to allow configuration of it metadata is set equal to the filename, eg `background-homepage.png`, directory, eg `/assets/images/background-homepage.png` or fully qualified, eg `{{ site.baseurl }}/assets/images/background-homepage.png`.

