### PR TITLE
Fix https request path

### DIFF
--- a/app/models/file.js
+++ b/app/models/file.js
@@ -353,7 +353,8 @@ module.exports = Backbone.Model.extend({
 
   url: function() {
     var branch = this.collection.branch || this.branch || this.get('branch');
-    return pathUtil.join(this.collection.repo.url(), 'contents', this.get('path') + '?ref=' + branch.get('name'));
+    var fullPath = this.collection.repo.url() + pathUtil.join('/contents', this.get('path') + '?ref=' + branch.get('name'));
+    return fullPath;
   },
 
   validate: function(attributes, options) {

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -81,7 +81,6 @@ module.exports = Backbone.Model.extend({
 
   url: function() {
     var url = config.api + '/repos/' + this.get('owner').login + '/' + this.get('name');
-    console.log(url);
     return url;
   }
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -149,7 +149,7 @@ gulp.task('watch', ['build-app', 'build-tests', 'css'], function() {
 
 var testTask = shell.task([
   './node_modules/mocha-phantomjs/bin/mocha-phantomjs test/index.html'
-], {ignoreErrors: true});
+]);
 
 gulp.task('test', ['build-tests'], testTask);
 

--- a/test/spec/models/file.js
+++ b/test/spec/models/file.js
@@ -114,8 +114,8 @@ describe('file model', function() {
       it('properly formats urls', function () {
         var file = mockFile('', filedata);
         file.set('path', '///this-is-crazy///');
-        file.collection.repo.url = function () { return 'www.test.com'; };
-        expect(file.url()).to.equal('www.test.com/contents/this-is-crazy/?ref=master');
+        file.collection.repo.url = function () { return 'https://www.test.com'; };
+        expect(file.url()).to.equal('https://www.test.com/contents/this-is-crazy/?ref=master');
       })
     })
   })


### PR DESCRIPTION
This was a dumb mistake I made using nodes `path` module to join urls. The resulting url would look like `https:/something.com` and would get mangled on the reverse proxy redirect. This fixes that and closes #1065.