### PR TITLE
added language direction for arabic. #645

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -13,7 +13,7 @@
 .toolbar .group       { margin-right:15px; margin-left:0; }
 .dialog.link          { right:23px; left:auto; }
 .dialog.no-directory  { right:50px; left:auto; }
-
+.CodeMirror           { direction: rtl; }
 
 /* Helper Classes Reversed */
 .fl     { float:right; }

--- a/templates/app.html
+++ b/templates/app.html
@@ -1,4 +1,4 @@
-<% if (locale.current() === 'he-IL') { %>
+<% if (locale.current() === 'he-IL' || locale.current() === 'ar') { %>
   <link rel='stylesheet' href='./style-rtl.css'>
 <% } %>
 


### PR DESCRIPTION
I find another way to support RTL direction, as `sytle-rtl.css` contains the needed work for the interface, I just added a class to make editor direction is RTL too, and toggle it on for both Arabic and Hebrew.