### PR TITLE
Fix Error Selecting Branches After the First 100

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+# Use a package of configuration called an orb.
+orbs:
+  # Declare a dependency on the welcome-orb
+  welcome: circleci/welcome-orb@0.3.1
+# Orchestrate or schedule a set of jobs
+workflows:
+  # Name the workflow "welcome"
+  welcome:
+    # Run the welcome/run job in its own container
+    jobs:
+      - welcome/run

--- a/app/collections/branches.js
+++ b/app/collections/branches.js
@@ -24,7 +24,7 @@ module.exports = Backbone.Collection.extend({
     var cb = options.success;
 
     var success = (function(res, statusText, xhr) {
-      this.add(res);
+      this.add(this.parse(res));
       util.parseLinkHeader(xhr, {
         success: success,
         complete: cb

--- a/test/fixtures/get-branch-response.js
+++ b/test/fixtures/get-branch-response.js
@@ -1,0 +1,21 @@
+function makeBranch(i) {
+  var sha = "000000000000000000000000000000000000000" + i;
+  return {
+    name: "commit " + i,
+    commit: {
+      sha: sha,
+      url: "https://api.github.com/repos/test/test/commits/" + sha
+    }
+  };
+}
+
+var branches = [];
+
+var i = 0;
+
+while (i < 100) {
+  branches.push(makeBranch(i));
+  i++;
+}
+
+module.exports = branches;

--- a/test/index.js
+++ b/test/index.js
@@ -17,5 +17,6 @@ require('./spec/views/file');
 require('./spec/views/metadata');
 require('./spec/views/meta-forms');
 require('./spec/views/header');
+require("./spec/collections/branches");
 require('./spec/collections/files');
 require('./spec/collections/orgs');

--- a/test/spec/collections/branches.js
+++ b/test/spec/collections/branches.js
@@ -1,0 +1,55 @@
+var Branches = require("../../../app/collections/branches");
+var branchResponse = require("../../fixtures/get-branch-response.js");
+
+var server;
+var branches = new Branches(null, {
+  repo: {
+    url: function() {
+      return "/blah";
+    }
+  }
+});
+
+describe("branches collection", function() {
+  beforeEach(function() {
+    server = sinon.fakeServer.create();
+    server.autoRespond = true;
+    server.respondWith("GET", branches.url(), [
+      200,
+      {
+        Link: [
+          '</blah/branches?per_page=100&page=2>; rel="next"',
+          ' </blah/branches?per_page=100&page=2>; rel="last"'
+        ]
+      },
+      JSON.stringify(branchResponse)
+    ]);
+
+    server.respondWith("GET", branches.url() + "&page=2", [
+      200,
+      {
+        "Content-Type": "application/json",
+        Link: [' </blah/branches?per_page=100&page=3>; rel="last"']
+      },
+      JSON.stringify(branchResponse)
+    ]);
+  });
+
+  afterEach(function() {
+    server.restore();
+  });
+
+  it("sets repo on each of it's models", function(done) {
+    branches.fetch({
+      success: function() {
+        expect(branches.length).to.equal(200);
+        expect(
+          branches.models.every(function(m) {
+            return !!m.repo;
+          })
+        ).to.be.true;
+        done();
+      }
+    });
+  });
+});


### PR DESCRIPTION
In projects that have more than 100 branches, only the first 100 branches can successfully be used in Prose. This is happening because the original fetch is done using the standard Backbone collection `fetch` (https://github.com/prose/prose/blob/master/app/collections/branches.js#L34) whereas subsequent requests are done using raw jQuery (https://github.com/prose/prose/blob/master/app/util.js#L279). The original 100 branches, that are made using Backbone’s built in `fetch`, automatically call `parse` (https://github.com/prose/prose/blob/master/app/collections/branches.js#L13) which sets `this.repo` on the `Branch` model.  Branches that are fetched using jQuery never get `this.repo` set, which ends up causing an exception. The exception is thrown here https://github.com/prose/prose/blob/f5ba8461189ff35ef23c5f3eb3e1fa9fcb5813ec/app/collections/files.js#L320 and has this stack trace:
```
Uncaught TypeError: Cannot read property 'url' of undefined
    at n.url (prose.js:2)
    at Function.S.result (prose.js:37)
    at n.t.sync (prose.js:6)
    at n.sync (prose.js:6)
    at n.fetch (prose.js:6)
    at n.fetch (prose.js:2)
    at n.setModel (prose.js:3)
    at Object.parseLinkHeader (prose.js:2)
    at n.<anonymous> (prose.js:1)
    at d (prose.js:32)
```

This bug can be observed here: https://prose.io/#nodejs/node/tree/v6.x-staging

The fix for this solution ends up being rather small and just requires calling `parse` on each of the results returned by jQuery prior to adding them to the Branches collection