### PR TITLE
add config.baseurlexpression to support other `{{site.baseurl}}` expressions

### DIFF
--- a/app/collections/files.js
+++ b/app/collections/files.js
@@ -117,6 +117,7 @@ module.exports = Backbone.Collection.extend({
       this.config.rooturl = replacePlaceholders(placeholderValues, this.config.rooturl);
       this.config.media = replacePlaceholders(placeholderValues, this.config.media);
       this.config.siteurl = replacePlaceholders(placeholderValues, this.config.siteurl);
+      this.config.baseurlexpression = this.config.baseurlexpression || "{{site.baseurl}}"
 
       if (config.prose.metadata) {
         var metadata = config.prose.metadata;

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -293,8 +293,8 @@ module.exports = Backbone.View.extend({
             path = path.split(titleAttribute)[0];
           }
 
-          // Remove {{site.baseurl}}
-          path = path.replace('{{site.baseurl}}/', '/');
+
+          path = path.replace(this.config.baseurlexpression + '/', '/');
 
           // Prepend directory path if not site root relative
           path = /^\//.test(path) ? path.slice(1) :
@@ -1365,7 +1365,7 @@ module.exports = Backbone.View.extend({
     this.collection.upload(file, content, uploadPath, {
       success: (function(model, res, options) {
         var name = res.content.name;
-        var path = '{{site.baseurl}}/' + res.content.path;
+        var path = this.config.baseurlexpression+'/' + res.content.path;
 
         // Take the alt text from the insert image box on the toolbar
         var $alt = $('input[name="alt"]');

--- a/app/views/toolbar.js
+++ b/app/views/toolbar.js
@@ -398,7 +398,7 @@ module.exports = Backbone.View.extend({
         // Finally, clear the queue object
         this.queue = undefined;
       } else {
-        var src = '{{site.baseurl}}/' + $('input[name="url"]').val();
+        var src = this.config.baseurlexpression + '/' + $('input[name="url"]').val();
         var alt = $('input[name="alt"]').val();
         this.view.editor.replaceSelection('![' + alt + '](' + src + ')');
         this.view.editor.focus();


### PR DESCRIPTION
This pr is an attempt to fix https://github.com/prose/prose/issues/842.
It adds a new config setting (`baseurlexpression`) where you can set the expression that should be evaluated to get the sites baseurl.
e.g.
```
prose:
    baseurlexpression: "{{.Site.BaseURL}}"
```
**I was unable to test this so please review carefully.**