### PR TITLE
Bugfix: Folders were not properly decoded for naviagtion

### DIFF
--- a/app/views/files.js
+++ b/app/views/files.js
@@ -181,7 +181,7 @@ module.exports = Backbone.View.extend({
 
   navigate: function(e) {
     var target = e.currentTarget;
-    var path = target.href.split('#')[1];
+    var path = decodeURIComponent(target.href.split('#')[1]);
     var match = path.match(/tree\/([^\/]*)\/?(.*)$/);
 
     if (e && match) {


### PR DESCRIPTION
Addresses #1121 

The destination was not properly set on folders which were escaped prior to rendering. 

Example:
1. Navigate to [https://prose.io/#Tc-001/Prose-bug-repro/tree/main](https://prose.io/#Tc-001/Prose-bug-repro/tree/main)
2. Click into `folder with spaces`
3. Folder is seemingly blank
4. Navigate to [https://prose.io/#Tc-001/Prose-bug-repro/tree/main/Folder%20with%20spaces](https://prose.io/#Tc-001/Prose-bug-repro/tree/main/Folder%20with%20spaces)
5. Folder is no longer blank

This fix:
- Resolves issue by unescaping URIComponents before navigation when in app.