### PR TITLE
Change publish button behavior

### DIFF
--- a/app/models/file.js
+++ b/app/models/file.js
@@ -99,14 +99,10 @@ module.exports = Backbone.Model.extend({
     };
 
     res.content = resp.replace(/^(---\n)((.|\n)*?)---\n?/, function(match, dashes, frontmatter) {
-      var regex = /published: false/;
 
       try {
         // TODO: _.defaults for each key
         res.metadata = jsyaml.safeLoad(frontmatter);
-
-        // Default to published unless explicitly set to false
-        res.metadata.published = !regex.test(frontmatter);
       } catch(err) {
         console.log('ERROR encoding YAML');
         console.log(err);
@@ -149,7 +145,7 @@ module.exports = Backbone.Model.extend({
     var content = this.get('content') || '';
     var frontmatter;
 
-    if (metadata) {
+    if (metadata && !_.isEmpty(metadata)) {
       try {
         frontmatter = jsyaml.safeDump(metadata).trim();
       } catch(err) {

--- a/app/views/file.js
+++ b/app/views/file.js
@@ -993,8 +993,6 @@ module.exports = Backbone.View.extend({
         this.model.set('previous', filecontent);
         */
 
-        // TODO: why is this breaking?
-        // this.toolbar.updatePublishState();
 
         this.updateURL();
         this.sidebar.close();

--- a/app/views/metadata.js
+++ b/app/views/metadata.js
@@ -268,14 +268,6 @@ module.exports = Backbone.View.extend({
         group[0].value : _.pluck(group, 'value');
     });
 
-    // TODO does this always default metadata.published to true?
-    if (this.view.toolbar &&
-       this.view.toolbar.publishState() ||
-       (metadata && metadata.published)) {
-      metadata.published = true;
-    } else {
-      metadata.published = false;
-    }
 
     // Get the title value from heading if it's available.
     // In testing environment, if the header doesn't render
@@ -301,7 +293,6 @@ module.exports = Backbone.View.extend({
         delete metadata[key];
       }
     }
-
     return metadata;
   },
 
@@ -351,7 +342,7 @@ module.exports = Backbone.View.extend({
       // Note, we don't want to include hidden elements,
       // titles, or published states here.
       else if (!renderedViews.length && value &&
-               key !== 'title' && key !== 'published' &&
+               key !== 'title' &&
                !_.find(hidden, function(d) { return d.name === key })){
         var raw = {};
         raw[key] = value;

--- a/app/views/toolbar.js
+++ b/app/views/toolbar.js
@@ -306,70 +306,39 @@ module.exports = Backbone.View.extend({
     }
   },
 
-  updatePublishState: function() {
-    // Update the publish key wording depening on what was saved
-    var $publishkey = this.$el.find('.publish-flag');
-    var key = $publishKey.attr('data-state');
-
-    if (key === 'true') {
-      $publishKey.html(t('actions.publishing.published') +
-                      '<span class="ico small checkmark"></span>');
-    } else {
-      $publishKey.html(t('actions.publishing.unpublished') +
-                      '<span class="ico small checkmark"></span>');
-    }
-  },
-
   togglePublishing: function(e) {
     var $target = $(e.currentTarget);
     var metadata = this.file.get('metadata');
     var published = metadata.published;
 
-    // TODO: remove HTML from view
-    // Toggling publish state when the current file is published live
-    if (published) {
-      if ($target.hasClass('published')) {
-        $target
-          .empty()
-          .append(t('actions.publishing.unpublish') +
-                '<span class="ico small checkmark"></span>' +
-                '<span class="popup round arrow-top">' +
-                t('actions.publishing.unpublishInfo') +
-                '</span>')
-          .removeClass('published')
-          .attr('data-state', false);
-      } else {
-        $target
-          .empty()
-          .append(t('actions.publishing.published') +
-                '<span class="ico small checkmark"></span>')
-          .addClass('published')
-          .attr('data-state', true);
-      }
-    } else {
-      if ($target.hasClass('published')) {
-        $target
-          .empty()
-          .append(t('actions.publishing.unpublished') +
-                '<span class="ico small checkmark"></span>')
-          .removeClass('published')
-          .attr('data-state', false);
-      } else {
-        $target
-          .empty()
-          .append(t('actions.publishing.publish') +
-                '<span class="ico small checkmark"></span>' +
-                '<span class="popup round arrow-top">' +
-                t('actions.publishing.publishInfo') +
-                '</span>')
-          .addClass('published')
-          .attr('data-state', true);
-      }
-    }
+    if (published === false) {
+      $target
+        .empty()
+        .append(t('actions.publishing.unpublish') +
+              '<span class="ico small cancel"></span>' +
+              '<span class="popup round arrow-top">' +
+              t('actions.publishing.publishInfo') +
+              '</span>')
+        .addClass('published')
+        .attr('data-state', true);
 
-    this.file.set('metadata', _.extend(metadata, {
-      published: !published
-    }));
+        this.file.set('metadata', _.omit(metadata, ['published']))
+    } else {
+      $target
+        .empty()
+        .append(t('actions.publishing.unpublished') +
+              '<span class="ico small checkmark"></span>' +
+              '<span class="popup round arrow-top">' +
+              t('actions.publishing.unpublishInfo') +
+              '</span>')
+        .removeClass('published')
+        .attr('data-state', false);
+        
+        this.file.set('metadata', {
+          ...metadata,
+          published: false
+        });
+    }
 
     this.view.makeDirty();
     return false;

--- a/templates/toolbar.html
+++ b/templates/toolbar.html
@@ -3,14 +3,19 @@
     <%= t('actions.draft.toPost') %><span class='ico small checkmark'></span>
     <span class='popup round arrow-top'><%= t('actions.draft.toPostInfo') %></span>
   </a>
-<% } else { %>
-  <% if (toolbar.metadata && toolbar.metadata.published) { %>
+<% } else if (toolbar.metadata) { %>
+  <% if (toolbar.metadata.published === false) { %>
+    <a href='#' class='publish-flag round contain' data-state='false'>
+      <%= t('actions.publishing.unpublished') %><span class='ico small checkmark'></span>
+    </a>
+  <% // This case is a UX backwards-compatibility measure; Some users may expect to see an affirmation here %>
+  <% } else if (toolbar.metadata.published === true) { %>
     <a href='#' class='publish-flag published round contain' data-state='true'>
       <%= t('actions.publishing.published') %><span class='ico small checkmark'></span>
     </a>
-  <% } else if (toolbar.metadata && !toolbar.metadata.published) { %>
-    <a href='#' class='publish-flag round contain' data-state='false'>
-      <%= t('actions.publishing.unpublished') %><span class='ico small checkmark'></span>
+  <% } else { %>
+    <a href='#' class='publish-flag round contain' data-state='true'>
+      <%= t('actions.publishing.unpublish') %><span class='ico small cancel'></span>
     </a>
   <% } %>
 <% } %>

--- a/test/spec/views/metadata.js
+++ b/test/spec/views/metadata.js
@@ -353,15 +353,13 @@ describe('Metadata editor view', function() {
       expect(values.hasOwnProperty('layout')).not.ok;
     });
 
-    it('does not remove title and published meta properties, even if they are unset', function () {
+    it('does not remove title meta property, even if they are unset', function () {
       model.set('metadata', {
         title: '',
-        published: ''
       });
       metadataEditor.render();
       var values = metadataEditor.getValue();
       expect(values.hasOwnProperty('title')).ok;
-      expect(values.hasOwnProperty('published')).ok;
     });
 
     it('textarea names do not collide with view methods', function() {
@@ -635,7 +633,7 @@ describe('Metadata editor view', function() {
         .to.deep.equal({text: 'hello world'});
     });
 
-    it('does not put title, publish, or hidden elements into the raw editor', function() {
+    it('does not put title, or hidden elements into the raw editor', function() {
       model.set('defaults', [{
         name: 'layout',
         field: {
@@ -644,7 +642,6 @@ describe('Metadata editor view', function() {
         }
       }]);
       model.set('metadata', {
-        published: true,
         title: 'hello world'
       });
       metadataEditor.render();


### PR DESCRIPTION
This change aims to resolve #111. While Prose was obviously written with first class support for Jekyll, it shouldn't enforce Jekyll semantics on every yaml frontmatter compatible markdown file. 

Furthermore it seems like Prose was using an outdated or incorrect spec for Jekyll.[ According to the Jekyll docs](https://jekyllrb.com/docs/front-matter/#:~:text=Set%20to%20false%20if%20you%20don%E2%80%99t%20want%20a%20specific%20post%20to%20show%20up%20when%20the%20site%20is%20generated.) the only value for `published` that is parsed is `false`, setting `published` to `true` appears to be duplicative.  

**Changes to functionality**
1. The published button now assumes a default state of that of an "Unpublish" button, as depicted:
![image](https://github.com/prose/prose/assets/10392896/7f6e393f-cb60-4873-b20a-184bf08cc399)
This better logically follows the flow of published by default, leaving the user with an option to unpublish a post. 
When clicked, the standard "Unpublished" button appears, with it's toggle back to an "Unpublish" button.
2. `published` is now treated like a standard metadata attribute in the editor. Happy to take feedback on this choice but made sense to me so that users still wanting to manually set `publish` to true (possibly for use in other frameworks that use it) can access it in the metadata panel.

There is some UI/X backwards compatibility left in where if a page has `publish` set to `true` the button will display the previous "Published" green check mark so that users expecting it on previously published pages see it.
![image](https://github.com/prose/prose/assets/10392896/cfa00c27-7e3c-4b0f-8746-aa3419db87d0)
The toggle on this button will go: Unpublished -> Unpublish. The goal here is to transition users away from expecting a "Published" marker.

I've also cleaned up an unused duplicative function, and fixed a bug where empty front-matter on a newly created page would trigger the frontmatter to render 
```
---
{}
---
```